### PR TITLE
Support to lazy load the disqus comments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -371,7 +371,7 @@ disqus:
   enable: false
   shortname:
   count: true
-  async: false
+  lazyload: false
 
 # Hypercomments
 #hypercomments_id:

--- a/_config.yml
+++ b/_config.yml
@@ -371,6 +371,7 @@ disqus:
   enable: false
   shortname:
   count: true
+  async: false
 
 # Hypercomments
 #hypercomments_id:

--- a/layout/_third-party/comments/disqus.swig
+++ b/layout/_third-party/comments/disqus.swig
@@ -11,10 +11,31 @@
         this.page.identifier = '{{ page.path }}';
         this.page.title = '{{ page.title| addslashes }}';
       };
-      var d = document, s = d.createElement('script');
-      s.src = 'https://{{theme.disqus.shortname}}.disqus.com/embed.js';
-      s.setAttribute('data-timestamp', '' + +new Date());
-      (d.head || d.body).appendChild(s);
+      function loadComments () {
+        var d = document, s = d.createElement('script');
+        s.src = 'https://{{theme.disqus.shortname}}.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', '' + +new Date());
+        (d.head || d.body).appendChild(s);
+      }
+      {% if theme.disqus.async %}
+        $(function () {
+          var offsetTop = $('#comments').offset().top - $(window).height();
+          if (offsetTop <= 0) {
+            // load directly when there's no a scrollbar
+            loadComments();
+          } else {
+            $(window).on('scroll.disqus_scroll', function () {
+              var scrollTop = document.documentElement.scrollTop;
+              if (scrollTop >= offsetTop) {
+                $(window).off('.disqus_scroll');
+                loadComments();
+              }
+            });
+          }
+        });
+      {% else %}
+        loadComments();
+      {% endif %}
     </script>
   {% endif %}
 

--- a/layout/_third-party/comments/disqus.swig
+++ b/layout/_third-party/comments/disqus.swig
@@ -17,7 +17,7 @@
         s.setAttribute('data-timestamp', '' + +new Date());
         (d.head || d.body).appendChild(s);
       }
-      {% if theme.disqus.async %}
+      {% if theme.disqus.lazyload %}
         $(function () {
           var offsetTop = $('#comments').offset().top - $(window).height();
           if (offsetTop <= 0) {


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the new behavior?
Allow user to choice when the disqus comments will be loaded.
If the `theme.disqus.async` have been changed to `true`, the disqus will be loaded when the visitor scrolls the page to the bottom.

* Screens with this changes: N/A
* Link to demo site with this changes: https://tsanie.us/2018/01/10/lazyload-disqus/

### How to use?
In NexT `_config.yml`:
```yml
disqus:
  async: true
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
