### PR TITLE
Fix an issue about the categories/tags count.

### DIFF
--- a/layout/page.swig
+++ b/layout/page.swig
@@ -31,7 +31,13 @@
         {% if page.type === "tags" %}
           <div class="tag-cloud">
             <div class="tag-cloud-title">
-                {{ _p('counter.tag_cloud', site.tags.length) }}
+                {% set visibleTags = 0 %}
+                {% for tag in site.tags %}
+                  {% if tag.length %}
+                    {% set visibleTags += 1 %}
+                  {% endif %}
+                {% endfor %}
+                {{ _p('counter.tag_cloud', visibleTags) }}
             </div>
             <div class="tag-cloud-tags">
               {{ tagcloud({min_font: 12, max_font: 30, amount: 300, color: true, start_color: '#ccc', end_color: '#111'}) }}
@@ -40,7 +46,13 @@
         {% elif page.type === 'categories' %}
           <div class="category-all-page">
             <div class="category-all-title">
-                {{ _p('counter.categories', site.categories.length) }}
+                {% set visibleCategories = 0 %}
+                {% for cat in site.categories %}
+                  {% if cat.length %}
+                    {% set visibleCategories += 1 %}
+                  {% endif %}
+                {% endfor %}
+                {{ _p('counter.categories', visibleCategories) }}
             </div>
             <div class="category-all">
               {{ list_categories() }}


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
I have an article in the **_drafts** that contains 2 tags: compression, pngquant.
But the tags page shows the number with all articles including the draft ones.

* Screens like this: 
![image](https://user-images.githubusercontent.com/980449/35039202-15e2016e-fbb8-11e7-944d-f51e59a85c9d.png)

## What is the new behavior?
This commit changes the variable from reading `site.tags.length` to `site.tags.filter(t => t.length).length`, to make sure the result number will be right. (Also changes the categories)

> But I'm not familiar with swig, so the single filter is splitted to 6 lines, so it looks like too verbose. 😒 

* Screens with this changes: 
![image](https://user-images.githubusercontent.com/980449/35039561-2e177812-fbb9-11e7-8791-aaacb4ad2155.png)

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

