### PR TITLE
Update google-analytics.swig

### DIFF
--- a/layout/_third-party/analytics/google-analytics.swig
+++ b/layout/_third-party/analytics/google-analytics.swig
@@ -1,10 +1,10 @@
 {% if theme.google_analytics %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ theme.google_analytics }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', '{{ theme.google_analytics }}', 'auto');
-  ga('send', 'pageview');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ theme.google_analytics }}');
 </script>
 {% endif %}


### PR DESCRIPTION
Fix the `net::ERR_ABORTED` in browser for the old `ga.js`.

Updated to the latest configuration.
No changes needed for `_config.yml`