### PR TITLE
Add pangu.js instead of auto_spacing in hexo

### DIFF
--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -12,6 +12,7 @@
   <title>{% block title %}{% endblock %}</title>
   {% include '_third-party/analytics/index.swig' %}
   {% include '_scripts/noscript.swig' %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pangu/3.3.0/pangu.min.js"></script>
 </head>
 
 <body itemscope itemtype="http://schema.org/WebPage" lang="{{ page.lang || page.language || config.language }}">
@@ -91,5 +92,6 @@
   {% include '_third-party/mathjax.swig' %}
   {% include '_third-party/scroll-cookie.swig' %}
   {% include '_third-party/exturl.swig' %}
+  <script>pangu.spacingPage();</script>
 </body>
 </html>


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To use auto spacing in hexo, you need to `$ npm install hexo-filter-auto-spacing --save` and `auto_spacing: ture`. but there are [many issues](https://github.com/hexojs/hexo-filter-auto-spacing/issues) using `hexo-filter-auto-spacing` in some special circumstance like chinese and english  headlines.

Issue Number(s): [#4](https://github.com/hexojs/hexo-filter-auto-spacing/issues/4), [#5](https://github.com/hexojs/hexo-filter-auto-spacing/issues/5), [#1608](https://github.com/iissnan/hexo-theme-next/issues/1608), [#27](https://github.com/hexojs/hexo-renderer-marked/issues/27)

## What is the new behavior?

I recommend to use the [pangu.js](https://github.com/vinta/pangu.js) to realize the auto spacing. `$ npm install pangu --save` seems to be not working. I need to add the js in `\themes\next\layout\_layout.swig`

- It seems just a need for environment in chinese and english.
-  If you have already  installed the [hexo-filter-auto-spacing](https://github.com/hexojs/hexo-filter-auto-spacing) in your local files, you must `npm uninstall hexo-filter-auto-spacing` firstly.
- Then you can set `auto_spacing: false` in your root `_config.yml` , or just comment it.

* Link to demo site with this changes: http://saili.science/2017/04/02/github-for-win/

### Files modified:

1.	`\themes\next\layout\_layout.swig`

-  add `<script src="https://cdnjs.cloudflare.com/ajax/libs/pangu/3.3.0/pangu.min.js"></script>` in   `<head>`
- add `<script>pangu.spacingPage();</script>` in `<body>`

### How it looks?

![_20180119144008](https://user-images.githubusercontent.com/8521181/35137900-b21a20ce-fd26-11e7-8c55-3cc736a8aa29.png)
