### PR TITLE
Make per_page default to true to make math lazyloaded

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -375,10 +375,10 @@ font:
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
-  # in order to render math equations in post
-  per_page: false
+  # Default(true) will load mathjax/katex script on demand
+  # That is it only render those page who has 'mathjax: true' in Front Matter.
+  # If you set it to false, it will load mathjax/katex srcipt EVERY PAGE.
+  per_page: true
 
   engine: mathjax
   #engine: katex

--- a/_config.yml
+++ b/_config.yml
@@ -375,10 +375,10 @@ font:
 math:
   enable: false
 
-  # Default(true) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
+  # Default(false) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: true
+  per_page: false
 
   engine: mathjax
   #engine: katex

--- a/_config.yml
+++ b/_config.yml
@@ -375,10 +375,10 @@ font:
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
+  # Default(true) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: false
+  per_page: true
 
   engine: mathjax
   #engine: katex

--- a/docs/MATH.md
+++ b/docs/MATH.md
@@ -138,10 +138,10 @@ If your content of config just directly after the config name, then a space is n
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
-  # in order to render math equations in post
-  per_page: false
+  # Default(true) will load mathjax/katex script on demand
+  # That is it only render those page who has 'mathjax: true' in Front Matter.
+  # If you set it to false, it will load mathjax/katex srcipt EVERY PAGE.
+  per_page: true
 
   engine: mathjax
   #engine: katex
@@ -173,15 +173,13 @@ math:
 
 ### per_page
 
-`true` or `false`, default is `false`.
+`true` or `false`, default is `true`.
 
 This option is to control whether to render Math Equations every page.
 
-The behavior of default (`false`) is to render Math Equations on **every page**.
+The behavior of default (`true`) is to render Math Equations **on demand**.
 
-When you set it to `true`, it will only render the post with `mathjax: true` Front Matter.
-
-If your post's Front Matter doesn't have `mathjax: true` or you set `mathjax: false`, then NexT will not render Math Equations for those posts.
+It will only render those posts which have `mathjax: true` in their Front Matter.
 
 For example:
 
@@ -210,6 +208,8 @@ title: 'Not Render Math Either'
 ---
 ....
 ```
+
+When you set it to `false`, the math will be render on **EVERY PAGE**.
 
 ### cdn
 

--- a/docs/MATH.md
+++ b/docs/MATH.md
@@ -138,10 +138,10 @@ If your content of config just directly after the config name, then a space is n
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
+  # Default(true) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: false
+  per_page: true
 
   engine: mathjax
   #engine: katex
@@ -173,13 +173,13 @@ math:
 
 ### per_page
 
-`true` or `false`, default is `false`.
+`true` or `false`, default is `true`.
 
 This option is to control whether to render Math Equations every page.
 
-The behavior of default (`false`) is to render Math Equations on **every page**.
+The behavior of default (`true`) is to render Math Equations on **every page**.
 
-When you set it to `true`, it will only render the post with `mathjax: true` Front Matter.
+When you set it to `false`, it will only render the post with `mathjax: true` Front Matter.
 
 If your post's Front Matter doesn't have `mathjax: true` or you set `mathjax: false`, then NexT will not render Math Equations for those posts.
 

--- a/docs/MATH.md
+++ b/docs/MATH.md
@@ -138,10 +138,10 @@ If your content of config just directly after the config name, then a space is n
 math:
   enable: false
 
-  # Default(true) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
+  # Default(false) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: true
+  per_page: false
 
   engine: mathjax
   #engine: katex
@@ -173,13 +173,13 @@ math:
 
 ### per_page
 
-`true` or `false`, default is `true`.
+`true` or `false`, default is `false`.
 
 This option is to control whether to render Math Equations every page.
 
-The behavior of default (`true`) is to render Math Equations on **every page**.
+The behavior of default (`false`) is to render Math Equations on **every page**.
 
-When you set it to `false`, it will only render the post with `mathjax: true` Front Matter.
+When you set it to `true`, it will only render the post with `mathjax: true` Front Matter.
 
 If your post's Front Matter doesn't have `mathjax: true` or you set `mathjax: false`, then NexT will not render Math Equations for those posts.
 

--- a/docs/zh-Hans/MATH.md
+++ b/docs/zh-Hans/MATH.md
@@ -140,10 +140,10 @@ markdown:
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
-  # in order to render math equations in post
-  per_page: false
+  # Default(true) will load mathjax/katex script on demand
+  # That is it only render those page who has 'mathjax: true' in Front Matter.
+  # If you set it to false, it will load mathjax/katex srcipt EVERY PAGE.
+  per_page: true
 
   engine: mathjax
   #engine: katex
@@ -164,7 +164,6 @@ math:
     cdn: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css
     # If you want to try the latest version of Katex, use one below instead
     #cdn: //cdn.jsdelivr.net/katex/latest/katex.min.css
-
 ```
 
 ### enable
@@ -175,13 +174,11 @@ math:
 
 ### per_page
 
-`true` 或者 `false`，默认为 `false`。
+`true` 或者 `false`，默认为 `true`。
 
 这个选项是控制是否在每篇文章都渲染数学公式；
 
-默认(`false`)的行为是**对每篇文章都进行数学公式渲染**；
-
-`true` 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
+默认(`true`) 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
 
 如果 Front Matter 中不含有 `mathjax: true`，或者 `mathjax: false`，那么 NexT 将不会对这些文章进行数学公式渲染。
 
@@ -212,6 +209,8 @@ title: 'Not Render Math Either'
 ---
 ....
 ```
+
+当你将它设置为 `false` 时，它就会在每个页面都加载 MathJax 或者 Katex 来进行数学公式渲染。
 
 ### cdn
 

--- a/docs/zh-Hans/MATH.md
+++ b/docs/zh-Hans/MATH.md
@@ -140,10 +140,10 @@ markdown:
 math:
   enable: false
 
-  # Default(false) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
+  # Default(true) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: false
+  per_page: true
 
   engine: mathjax
   #engine: katex
@@ -175,13 +175,13 @@ math:
 
 ### per_page
 
-`true` 或者 `false`，默认为 `false`。
+`true` 或者 `false`，默认为 `true`。
 
 这个选项是控制是否在每篇文章都渲染数学公式；
 
-默认(`false`)的行为是**对每篇文章都进行数学公式渲染**；
+默认(`true`)的行为是**对每篇文章都进行数学公式渲染**；
 
-`true` 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
+`false` 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
 
 如果 Front Matter 中不含有 `mathjax: true`，或者 `mathjax: false`，那么 NexT 将不会对这些文章进行数学公式渲染。
 

--- a/docs/zh-Hans/MATH.md
+++ b/docs/zh-Hans/MATH.md
@@ -140,10 +140,10 @@ markdown:
 math:
   enable: false
 
-  # Default(true) will load mathjax/katex srcipt EVERY PAGE
-  # If you set to false, you need to add 'mathjax: true' in Front Matter of post
+  # Default(false) will load mathjax/katex srcipt EVERY PAGE
+  # If you set to true, you need to add 'mathjax: true' in Front Matter of post
   # in order to render math equations in post
-  per_page: true
+  per_page: false
 
   engine: mathjax
   #engine: katex
@@ -175,13 +175,13 @@ math:
 
 ### per_page
 
-`true` 或者 `false`，默认为 `true`。
+`true` 或者 `false`，默认为 `false`。
 
 这个选项是控制是否在每篇文章都渲染数学公式；
 
-默认(`true`)的行为是**对每篇文章都进行数学公式渲染**；
+默认(`false`)的行为是**对每篇文章都进行数学公式渲染**；
 
-`false` 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
+`true` 的行为是**只对 Front Matter 中含有 `mathjax: true` 的文章进行数学公式渲染**。
 
 如果 Front Matter 中不含有 `mathjax: true`，或者 `mathjax: false`，那么 NexT 将不会对这些文章进行数学公式渲染。
 

--- a/layout/_third-party/math/index.swig
+++ b/layout/_third-party/math/index.swig
@@ -1,5 +1,5 @@
 {% if theme.math.enable %}
-  {% if not theme.math.per_page or (page.total or page.mathjax) %}
+  {% if theme.math.per_page or (page.total or page.mathjax) %}
     {% if theme.math.engine == 'mathjax' %}
       {% include 'mathjax.swig' %}
     {% elif theme.math.engine == 'katex' %}
@@ -7,4 +7,3 @@
    {% endif %}
   {% endif %}
 {% endif %}
-

--- a/layout/_third-party/math/index.swig
+++ b/layout/_third-party/math/index.swig
@@ -1,5 +1,5 @@
 {% if theme.math.enable %}
-  {% if theme.math.per_page or (page.total or page.mathjax) %}
+  {% if not theme.math.per_page or (page.total or page.mathjax) %}
     {% if theme.math.engine == 'mathjax' %}
       {% include 'mathjax.swig' %}
     {% elif theme.math.engine == 'katex' %}
@@ -7,3 +7,4 @@
    {% endif %}
   {% endif %}
 {% endif %}
+


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
`per_page` default is `false` and will render math EVERY PAGE.

## What is the new behavior?

`per_page` default is `true` and will render math on demand.

That is it will only render those posts with `mathjax: true` by default

Related: https://github.com/theme-next/hexo-theme-next/pull/32#issuecomment-359286588

### How to use?
In NexT `_config.yml`:
```yml
# This is default opiton now
math:
  enable: false
  per_page: true
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
