### PR TITLE
Support to scroll the right position when the visitor open a page by …

### DIFF
--- a/layout/_third-party/bookmark.swig
+++ b/layout/_third-party/bookmark.swig
@@ -3,7 +3,7 @@
   <script src="{{ bookmark_uri }}"></script>
   <script type="text/javascript">
   {% if is_post() %}
-    bookmark.scrollToMark('{{ theme.bookmark.save }}');
+    bookmark.scrollToMark('{{ theme.bookmark.save }}', "#{{ __('post.more') }}");
   {% else %}
     bookmark.loadBookmark();
   {% endif %}


### PR DESCRIPTION
…clicking the 'Read More' button.

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
If a page has a position record, even though the visitor click the 'Read More' button from Homepage, it will still scroll to the record position.

Issue Number(s): N/A

## What is the new behavior?
If the user open the page from the 'Read More' button, it should take the visitor to the right continuous position.
And If open the page through the other method, it will take him to the last position well.

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
As it is before.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
