### PR TITLE
Fix #78

### DIFF
--- a/layout/_third-party/math/index.swig
+++ b/layout/_third-party/math/index.swig
@@ -1,5 +1,16 @@
 {% if theme.math.enable %}
-  {% if not theme.math.per_page or (page.total or page.mathjax) %}
+  {% set is_index_has_math = false %}
+
+  {# At home, check if there has `mathjax: true` post #}
+  {% if is_home() %}
+    {% for post in page.posts %}
+      {% if post.mathjax and not is_index_has_math %}
+        {% set is_index_has_math = true %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% if not theme.math.per_page or (is_index_has_math or page.mathjax) %}
     {% if theme.math.engine == 'mathjax' %}
       {% include 'mathjax.swig' %}
     {% elif theme.math.engine == 'katex' %}
@@ -7,4 +18,3 @@
    {% endif %}
   {% endif %}
 {% endif %}
-


### PR DESCRIPTION
Only load math script in homepage whose posts contain `mathjax: true`
and the page with `mathjax: true`

<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Math script will be loaded in tags and achives pages with no `mathjax: true`

Issue Number(s): #78 

## What is the new behavior?

Math script will only be loaded in two situations:

1. The current page contains a front matter `mathjax: true`

2. The current page is homepage and it has a least one post which contains the `mathjax: true` front matter

* Screens with this changes: 

Homepage with no post contains `mathjax: true`:
![image](https://user-images.githubusercontent.com/12459199/35277236-65cda6c6-0089-11e8-950e-2c2be218cd79.png)

Homepage with post contains `mathjax: true`:
![image](https://user-images.githubusercontent.com/12459199/35277262-7e03ff4c-0089-11e8-800a-7ea4c985cb17.png)

Post with no `mathjax: true`:
![image](https://user-images.githubusercontent.com/12459199/35277293-a35b8d0a-0089-11e8-8256-f8f5b1796f34.png)

Post with `mathjax: true`:
![image](https://user-images.githubusercontent.com/12459199/35277334-c11e37f2-0089-11e8-80af-9d9e69c5c4e3.png)



* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
No changes of config file.
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
