### PR TITLE
Fix the exists categories/tags count issue in the sidebar.

### DIFF
--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -64,7 +64,11 @@
                 {% set hasCategoriesPage = categoriesPageQuery.length > 0 %}
                 <div class="site-state-item site-state-categories">
                   {% if hasCategoriesPage %}<a href="{{ url_for(categoriesPageQuery[0].path) }}">{% endif %}
-                    <span class="site-state-item-count">{{ site.categories.length }}</span>
+                    {% set visibleCategories = 0 %}
+                    {% for cat in site.categories %}
+                      {% if cat.length %}{% set visibleCategories += 1 %}{% endif %}
+                    {% endfor %}
+                    <span class="site-state-item-count">{{ visibleCategories }}</span>
                     <span class="site-state-item-name">{{ __('state.categories') }}</span>
                   {% if hasCategoriesPage %}</a>{% endif %}
                 </div>
@@ -75,7 +79,11 @@
                 {% set hasTagsPage = tagsPageQuery.length > 0 %}
                 <div class="site-state-item site-state-tags">
                   {% if hasTagsPage %}<a href="{{ url_for(tagsPageQuery[0].path) }}">{% endif %}
-                    <span class="site-state-item-count">{{ site.tags.length }}</span>
+                    {% set visibleTags = 0 %}
+                    {% for tag in site.tags %}
+                      {% if tag.length %}{% set visibleTags += 1 %}{% endif %}
+                    {% endfor %}
+                    <span class="site-state-item-count">{{ visibleTags }}</span>
                     <span class="site-state-item-name">{{ __('state.tags') }}</span>
                   {% if hasTagsPage %}</a>{% endif %}
                 </div>


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number(s): N/A

## What is the new behavior?
I found the issue is still exists in the sidebar, just fix it. Related: https://github.com/theme-next/hexo-theme-next/pull/42

* Screens with this changes: N/A
* Link to demo site with this changes: https://tsanie.us/about/

### How to use?
N/A

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
