### PR TITLE
Fix an issue about the algolia search overlay.

### DIFF
--- a/source/css/_common/components/third-party/algolia-search.styl
+++ b/source/css/_common/components/third-party/algolia-search.styl
@@ -6,6 +6,8 @@
   left: 0
   z-index: 2080
   background-color: rgba(0, 0, 0, 0.3)
+  +mobile()
+    display: none;
 
 .algolia-popup
   overflow: hidden


### PR DESCRIPTION
- related: https://github.com/iissnan/hexo-theme-next/issues/1764

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Since [the **Muse** layout](https://github.com/theme-next/hexo-theme-next/blob/master/source/css/_schemes/Muse/_menu.styl#L2) specify the `.site-nav` is an **absolute** position with a z-index: 1030 in the mobile layout, that will lead its child `.algolia-popup` would be covered by the `.algolia-pop-overlay` (which with a [z-index: 2080](https://github.com/theme-next/hexo-theme-next/blob/master/source/css/_common/components/third-party/algolia-search.styl#L7))

Issue Number(s): https://github.com/iissnan/hexo-theme-next/issues/1764

## What is the new behavior?
Set the `.algolia-pop-overlay` to be hidden in the mobile layout, because the `.algolia-popup` will fill the entire screen.

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
N/A

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
