### PR TITLE
Add a switch to choice whether it will unescape the HTML strings for local searching

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -655,6 +655,8 @@ local_search:
   trigger: auto
   # show top n results per article, show all results by setting to -1
   top_n_per_article: 1
+  # unescape html strings to the readable one
+  unescape: false
 
 # Bookmark Support
 # Dependencies: https://github.com/theme-next/theme-next-bookmark

--- a/layout/_third-party/search/localsearch.swig
+++ b/layout/_third-party/search/localsearch.swig
@@ -48,6 +48,21 @@
         .css('overflow', 'hidden');
       $("#search-loading-icon").css('margin', '20% auto 0 auto').css('text-align', 'center');
 
+      {% if theme.local_search.unescape %}
+        // ref: https://github.com/ForbesLindesay/unescape-html
+        var unescapeHtml = function(html) {
+          return String(html)
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, '\'')
+            .replace(/&#x3A;/g, ':')
+            // replace all the other &#x; chars
+            .replace(/&#(\d+);/g, function (m, p) { return String.fromCharCode(p); })
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&amp;/g, '&');
+        };
+      {% endif %}
+
       $.ajax({
         url: path,
         dataType: isXml ? "xml" : "json",
@@ -81,6 +96,9 @@
                 var title = data.title.trim();
                 var titleInLowerCase = title.toLowerCase();
                 var content = data.content.trim().replace(/<[^>]+>/g,"");
+                {% if theme.local_search.unescape %}
+                content = unescapeHtml(content);
+                {% endif %}
                 var contentInLowerCase = content.toLowerCase();
                 var articleUrl = decodeURIComponent(data.url);
                 var indexOfTitle = [];


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
The local search plugin will escape some special chars to the safety one, like `<` to `&lt;`, and `&` to `&amp;`, etc. (it's no problem).
But when you start a searching using the internal plugin, it will search keywords from the escaped one, for example, you couldn't find the `<`, because it has been escaped to `&lt;`.

* Screens: 
![image](https://user-images.githubusercontent.com/980449/35437593-0a56bd5e-02ce-11e8-9884-9652a5dfafcd.png)
or
![image](https://user-images.githubusercontent.com/980449/35437602-0f6a3de8-02ce-11e8-8f9a-36b870051501.png)

## What is the new behavior?
Now it add a switch to the `_config.yml`, when you turning it on, the data will be unescaped before searching.

* Screens with this changes: N/A
![image](https://user-images.githubusercontent.com/980449/35437652-5f89129a-02ce-11e8-936c-6097bbea9f5c.png)
or
![image](https://user-images.githubusercontent.com/980449/35437656-6353f818-02ce-11e8-8901-733d6842ba6a.png)

* Link to demo site with this changes: https://tsanie.us

### How to use?
In NexT `_config.yml`:
```yml
local_search:
  ...
  # unescape html strings to the readable one
  unescape: true
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
