### PR TITLE
Use jsdelivr as default cdn and update docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -388,22 +388,24 @@ math:
 
   # hexo-rendering-pandoc (or hexo-renderer-kramed) needed to full MathJax support.
   mathjax:
+    # Use 2.7.1 as default, jsdelivr as default CDN, works everywhere even in China
+    cdn: //cdn.jsdelivr.net/npm/mathjax@2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
     # For newMathJax CDN (cdnjs.cloudflare.com) with fallback to oldMathJax (cdn.mathjax.org).
-    cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+    #cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
     # For direct link to MathJax.js with CloudFlare CDN (cdnjs.cloudflare.com).
     #cdn: //cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML
-    # For automatic detect latest version link to MathJax.js and get from Bootcdn.
+    # For automatic detect latest version link to MathJax.js and get from Bootcss.
     #cdn: //cdn.bootcss.com/mathjax/2.7.1/latest.js?config=TeX-AMS-MML_HTMLorMML
 
   # hexo-renderer-markdown-it-plus (or hexo-renderer-markdown-it with markdown-it-katex plugin)
   # needed to full Katex support.
   katex:
-    # Use Katex 0.7.1 as default
-    cdn: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css
-    # For whose visitors are mostly in China
+    # Use 0.7.1 as default, jsdelivr as default CDN, works everywhere even in China
+    cdn: //cdn.jsdelivr.net/npm/katex@0.7.1/dist/katex.min.css
+    # CDNJS, provided by cloudflare, maybe the best CDN, but not works in China
+    #cdn: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css
+    # Bootcss, works great in China, but not so well in other region
     #cdn: //cdn.bootcss.com/KaTeX/0.7.1/katex.min.css
-    # If you want to try the latest version of Katex, use one below instead
-    #cdn: //cdn.jsdelivr.net/katex/latest/katex.min.css
 
 # Han Support
 # Dependencies: https://github.com/theme-next/theme-next-han

--- a/docs/MATH.md
+++ b/docs/MATH.md
@@ -210,15 +210,22 @@ title: 'Not Render Math Either'
 ....
 ```
 
-When you set it to `false`, the math will be render on **EVERY PAGE**.
+When you set it to `false`, the math will be rendered on **EVERY PAGE**.
 
 ### cdn
 
 Both MathJax and Katex provide a config `cdn`, if you don't know what is `cdn`, **do not touch it**.
 
-For MathJax, we use a fallback CDN as default and provide other CDN as optional.
+Firstly, both MathJax and Katex use the [jsDelivr](https://www.jsdelivr.com/) as default CDN.
 
-For Katex, we use cdnjs as the default CDN and use the Katex 0.7.1 version. Due to the problem described above, if you need to use other CDN, please use the Katex 0.7.1 version.
-Of cause, we also provide a CDN which could automatically use the latest version of Katex, if you want to check the effect of it.
+Why choose the jsDelivr is because it is fast in everywhere, and jsDelivr has the valid ICP license issued by the Chinese government, it can be accessed in China pretty well.
 
-Particularly, if you are Chinese blogger, or most of your visitors are in China, because the default CDN is blocked in some parts of China, please use the `cdn.bootcss.com` version instead of the default `cdnjs.cloudflare.com` version.
+And we also provide other optional CDNs, including the famous [CDNJS](https://cdnjs.com/) and the [Bootcss](http://www.bootcdn.cn/) which has the quite high access speed in China.
+
+For MathJax, we are currently using the 2.7.1 version.
+
+For Katex, due to the problem described above, we are now using the 0.7.1 version.
+
+If you want to try the other CDN not included in the optional list, you must use the corresponding version.
+
+Particularly, if you are Chinese blogger or most of your visits are come from China, please note that **the CDNJS is blocked in some parts of China**, don't use it as CDN.

--- a/docs/zh-CN/MATH.md
+++ b/docs/zh-CN/MATH.md
@@ -136,6 +136,7 @@ markdown:
 如果配置的内容接在冒号后面，那么内容和冒号之间必须有一个空格(例如`enable: true`)
 
 ```yml
+
 # Math Equations Render Support
 math:
   enable: false
@@ -150,22 +151,24 @@ math:
 
   # hexo-rendering-pandoc (or hexo-renderer-kramed) needed to full MathJax support.
   mathjax:
+    # Use 2.7.1 as default, jsdelivr as default CDN, works everywhere even in China
+    cdn: //cdn.jsdelivr.net/npm/mathjax@2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
     # For newMathJax CDN (cdnjs.cloudflare.com) with fallback to oldMathJax (cdn.mathjax.org).
-    cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+    #cdn: //cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML
     # For direct link to MathJax.js with CloudFlare CDN (cdnjs.cloudflare.com).
     #cdn: //cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML
-    # For automatic detect latest version link to MathJax.js and get from Bootcdn.
+    # For automatic detect latest version link to MathJax.js and get from Bootcss.
     #cdn: //cdn.bootcss.com/mathjax/2.7.1/latest.js?config=TeX-AMS-MML_HTMLorMML
 
   # hexo-renderer-markdown-it-plus (or hexo-renderer-markdown-it with markdown-it-katex plugin)
   # needed to full Katex support.
   katex:
-    # Use Katex 0.7.1 as default
-    cdn: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css
-    # For whose visitors are mostly in China
+    # Use 0.7.1 as default, jsdelivr as default CDN, works everywhere even in China
+    cdn: //cdn.jsdelivr.net/npm/katex@0.7.1/dist/katex.min.css
+    # CDNJS, provided by cloudflare, maybe the best CDN, but not works in China
+    #cdn: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css
+    # Bootcss, works great in China, but not so well in other region
     #cdn: //cdn.bootcss.com/KaTeX/0.7.1/katex.min.css
-    # If you want to try the latest version of Katex, use one below instead
-    #cdn: //cdn.jsdelivr.net/katex/latest/katex.min.css
 ```
 
 ### enable
@@ -218,8 +221,16 @@ title: 'Not Render Math Either'
 
 MathJax 和 Katex 都提供了 `cdn` 的配置，如果你不知道什么是 `cdn` ，**请不要修改这个配置**。
 
-对于 MathJax 来说，默认采用了会自动 fallback 的 CDN，也提供了其他 CDN 作为可选项。
+首先，MathJax 和 Katex 都使用了 [jsDelivr](https://www.jsdelivr.com/) 作为默认 CDN；
 
-对于 Katex 来说，我们使用 cdnjs 作为默认 CDN，并采用 0.7.1 的 Katex 版本；由于上面提到的版本问题，如果你需要使用其他 CDN，也请使用 Katex 0.7.1 版本。当然，如果你想查看最新版本的 Katex 的效果，我们也提供了一个能自动获取最新版本的 Katex 的 CDN 作为可选项。
+之所以选择 jsDelivr 是因为它在全球各地都有比较不错的速度，而且具有中国官方颁布的 ICP 证书，在中国也能比较好地访问。
 
-特别的，对于中国的博客主，或者您博客的访问者大多来源于中国，由于默认的 CDN 在部分中国地区被墙，请使用 `cdn.bootcss.com` 版本的 CDN 替代默认的 `cdnjs.cloudflare.com` CDN。
+同时，我们也提供了其他的 CDN 备选方案，包括著名的 [CDNJS](https://cdnjs.com/) 和在中国地区具有不错访问效果的 [Bootcss](http://www.bootcdn.cn/)。
+
+对于 MathJax 来说，我们目前采用的版本为 2.7.1。
+
+对于 Katex，由于上面提到的版本问题，我们目前采用的版本为 0.7.1。
+
+如果你想尝试我们提供的备选方案以外的 CDN，请注意使用对应的版本。
+
+特别的，对于中国的博客主，或者您的博客访问大部分来源于中国，由于 CDNJS 在部分中国地区被墙，请不要使用 CDNJS 作为 CDN。


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current we use the CDNJS as the default CDN, which is blocked in some parts of China.

Issue Number(s): N/A

## What is the new behavior?

Use the jsDelivr as default math cdn

jsDelivr has the ICP license issued by Chinese government, and has pretty access speed in China.

see https://github.com/theme-next/hexo-theme-next/pull/98#issuecomment-362014034

* Screens with this changes:
![image](https://user-images.githubusercontent.com/12459199/35642606-f2a2f0e6-0706-11e8-930f-c3c49027c714.png)

![image](https://user-images.githubusercontent.com/12459199/35642641-12dc36a6-0707-11e8-8f04-a119d723534c.png)



* Link to demo site with this changes: https://wafer.li

### How to use?
In NexT `_config.yml`:
```yml
  mathjax:
    # Use 2.7.1 as default, jsdelivr as default CDN, works everywhere even in China
    cdn: //cdn.jsdelivr.net/npm/mathjax@2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML
  katex:
    # Use 0.7.1 as default, jsdelivr as default CDN, works everywhere even in China
    cdn: //cdn.jsdelivr.net/npm/katex@0.7.1/dist/katex.min.css
```

## Does this PR introduce a breaking change?
I am not so sure.
- [x] Yes.
- [ ] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
