### PR TITLE
Fix needmoreshare2 vendors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -891,7 +891,8 @@ vendors:
 
   # needMoreShare2
   # https://github.com/revir/need-more-share2
-  needMoreShare2:
+  needmoreshare2_js:
+  needmoreshare2_css:
 
 
 # Assets

--- a/layout/_partials/head/head.swig
+++ b/layout/_partials/head/head.swig
@@ -6,7 +6,7 @@
 
 {% if theme.needmoreshare2.enable %}
   {% set needmoreshare2_css = url_for(theme.vendors._internal + '/needsharebutton/needsharebutton.css') %}
-  {% if theme.vendors.needmoreshare2 %}
+  {% if theme.vendors.needmoreshare2_css %}
     {% set needmoreshare2_css = theme.vendors.needmoreshare2_css %}
   {% endif %}
   <link rel="stylesheet" href="{{ needmoreshare2_css }}">


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?

The needmoreshare2 vendors not work.

See here:
https://github.com/theme-next/hexo-theme-next/blob/92061f90d90ca2aeece57c611c46bd6e2a08cbe9/layout/_third-party/needsharebutton.swig#L3-L5

And here:
https://github.com/theme-next/hexo-theme-next/blob/1cb4d086bd31c061764ceadddc82a729e4dc3fd5/layout/_partials/head/head.swig#L9-L11

It needs the `needmoreshare2_js` and `needmoreshare2_css`, but the `vendors` section only has `needMoreShare2`
https://github.com/theme-next/hexo-theme-next/blob/802b9a88c4e39107427069d2d3583db33f9d4d6b/_config.yml#L892-L894

## What is the new behavior?

Change the `needMoreShare2` to `needmoreshare2_js` and `needmoreshare2_css` to make it work.

* Screens with this changes: N/A
* Link to demo site with this changes:  https://wafer.li

### How to use?
In NexT `_config.yml`:
```yml
vendors:
  ....
  needmoreshare2_js:
  needmoreshare2_css:
```

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
