### PR TITLE
Let the bookmark support the CDN

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -894,6 +894,11 @@ vendors:
   needmoreshare2_js:
   needmoreshare2_css:
 
+  # bookmark
+  # Internal version: 1.0.0
+  # https://github.com/theme-next/theme-next-bookmark
+  bookmark:
+
 
 # Assets
 css: css

--- a/layout/_third-party/bookmark.swig
+++ b/layout/_third-party/bookmark.swig
@@ -1,5 +1,8 @@
 {% if theme.bookmark and theme.bookmark.enable %}
   {% set bookmark_uri = url_for(theme.vendors._internal + '/bookmark/bookmark.min.js?v=1.0')%}
+  {% if theme.vendors.bookmark %}
+    {% set bookmark_uri = theme.vendors.bookmark %}
+  {% endif %}
   <script src="{{ bookmark_uri }}"></script>
   <script type="text/javascript">
   {% if is_post() %}


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number(s): N/A

## What is the new behavior?
There is no need to clone the bookmark repo into the `source/lib`, just set the CDN url instead.

* Screens with this changes: N/A
* Link to demo site with this changes: https://tsanie.us (removed the `source/lib/bookmark` directory)

### How to use?
In NexT `_config.yml`:
```yml
vendors:
  ...
  # use a CDN instead of clone the whole third-party repo
  bookmark: https://cdn.jsdelivr.net/gh/theme-next/theme-next-bookmark@1.0.0/bookmark.min.js
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
