### PR TITLE
add reading_progress to vendors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -904,6 +904,12 @@ vendors:
   # https://github.com/theme-next/theme-next-bookmark
   bookmark:
 
+  # reading_progress
+  # Internal version: 1.0
+  # https://github.com/theme-next/theme-next-reading-progress
+  # Example: https://cdn.jsdelivr.net/gh/theme-next/theme-next-reading-progress@1.0/reading_progress.js
+  reading_progress:
+
 
 # Assets
 css: css

--- a/_config.yml
+++ b/_config.yml
@@ -907,7 +907,7 @@ vendors:
   # reading_progress
   # Internal version: 1.0
   # https://github.com/theme-next/theme-next-reading-progress
-  # Example: https://cdn.jsdelivr.net/gh/theme-next/theme-next-reading-progress@1.0/reading_progress.js
+  # Example: https://cdn.jsdelivr.net/gh/theme-next/theme-next-reading-progress@1.1/reading_progress.min.js
   reading_progress:
 
 


### PR DESCRIPTION

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [ ] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [x] Other... Please describe: add field in `_config.yml`

## What is the current behavior?
User doesn't know reading_progress can use cdn.

Issue Number(s): #105 

## What is the new behavior?
User knows reading_progress can use cdn.

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
vendors:
  # something....
  reading_progress: #cdn url
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
