### PR TITLE
add hover text for PV UV

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -611,14 +611,17 @@ busuanzi_count:
   site_uv: true
   site_uv_header: <i class="fa fa-user"></i>
   site_uv_footer:
+  site_uv_title:
   # custom pv span for the whole site
   site_pv: true
   site_pv_header: <i class="fa fa-eye"></i>
   site_pv_footer:
+  site_pv_title:
   # custom pv span for one page only
   page_pv: true
   page_pv_header: <i class="fa fa-file-o"></i>
   page_pv_footer:
+  page_pv_title:
 
 
 # Tencent analytics ID

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -216,7 +216,7 @@
 
           {% if not is_index and theme.busuanzi_count.enable and theme.busuanzi_count.page_pv %}
             <span class="post-meta-divider">|</span>
-            <span class="page-pv">{{ theme.busuanzi_count.page_pv_header }}
+            <span class="page-pv" title={{ theme.busuanzi_count.page_pv_title }}>{{ theme.busuanzi_count.page_pv_header }}
             <span class="busuanzi-value" id="busuanzi_value_page_pv" ></span>{{ theme.busuanzi_count.page_pv_footer }}
             </span>
           {% endif %}

--- a/layout/_third-party/analytics/busuanzi-counter.swig
+++ b/layout/_third-party/analytics/busuanzi-counter.swig
@@ -3,7 +3,7 @@
   <script async src="https://dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 
   {% if theme.busuanzi_count.site_uv %}
-    <span class="site-uv">
+    <span class="site-uv" title={{ theme.busuanzi_count.site_uv_title }}>
       {{ theme.busuanzi_count.site_uv_header }}
       <span class="busuanzi-value" id="busuanzi_value_site_uv"></span>
       {{ theme.busuanzi_count.site_uv_footer }}
@@ -11,7 +11,7 @@
   {% endif %}
 
   {% if theme.busuanzi_count.site_pv %}
-    <span class="site-pv">
+    <span class="site-pv" title={{ theme.busuanzi_count.site_pv_title }}>
       {{ theme.busuanzi_count.site_pv_header }}
       <span class="busuanzi-value" id="busuanzi_value_site_pv"></span>
       {{ theme.busuanzi_count.site_pv_footer }}


### PR DESCRIPTION
<!-- ATTENTION!
IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION WE MIGHT CLOSE YOUR ISSUE WITHOUT INVESTIGATING.
如果你不填充下面的内容，我们可能会直接关闭你的 issue。

If you want to fast resolve your issue, WRITE IT IN ENGLISH, please. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!
You may delete this recomendations and use template which is placed below.
-->

### I agree and want to create new issue <!-- (我确认我已经查看了) -->

<!-- Check all with [x] (把 [ ] 换成 [X] 来选择) -->
- [x] Yes, I was on [Hexo Docs page](https://hexo.io/docs/), especially on [Templates](https://hexo.io/docs/templates.html), [Variables](https://hexo.io/docs/variables.html), [Helpers](https://hexo.io/docs/helpers.html) and [Troubleshooting](https://hexo.io/docs/troubleshooting.html).
- [x] Yes, I was on [NexT Documentation Site](http://theme-next.org/docs/).
- [x] And yes, I already searched for current [issues](https://github.com/theme-next/hexo-theme-next/issues?utf8=%E2%9C%93&q=is%3Aissue) and this is not help to me.

***

### Expected behavior <!-- (预期行为) -->

hover text for PV&UV， instead of header&footer.

Hover text is more concise than footer & header.

- [demo with hover text](http://xusong.vip/2018/01/25/web/blog-framework/nodejs-hexo/Hexo%E4%BD%BF%E7%94%A8%E5%BB%BA%E8%AE%AE/)   see *pv uv*

```yml
busuanzi_count:
  # count values only if the other configs are false
  enable: true
  # custom uv span for the whole site
  site_uv: true
  site_uv_header: <i class="fa fa-user"></i>
  site_uv_footer:
  site_uv_title: 本站到访人数
  # custom pv span for the whole site
  site_pv: true
  site_pv_header: <i class="fa fa-eye"></i>
  site_pv_footer:
  site_pv_title: 本站访问量
  # custom pv span for one page only
  page_pv: true
  page_pv_header: <i class="fa fa-file-o"></i>
  page_pv_footer:
  page_pv_title: 本页阅读量

```


### Actual behavior <!-- (实际行为) -->

only header & footer is availabel.
- [demo without hover text](https://tsanie.us/2018/01/10/lazyload-disqus/)  see *pv uv* & other *count*

```yml
busuanzi_count:
  # count values only if the other configs are false
  enable: true
  # custom uv span for the whole site
  site_uv: true
  site_uv_header: <i class="fa fa-user"></i>
  site_uv_footer:
  # custom pv span for the whole site
  site_pv: true
  site_pv_header: <i class="fa fa-eye"></i>
  site_pv_footer:
  # custom pv span for one page only
  page_pv: true
  page_pv_header: <i class="fa fa-file-o"></i>
  page_pv_footer:

```




### Steps to reproduce the behavior <!-- (重现步骤) -->
1. N/A
2. N/A
3. N/A

* Link to demo site with this issue:      
http://xusong.vip/

* Link(s) to source code or any usefull link(s): N/A



<bountysource-plugin>

---
Want to back this issue? **[Post a bounty on it!](https://www.bountysource.com/issues/54581963-why-not-add-hover-text-for-pv-uv?utm_campaign=plugin&utm_content=tracker%2F83013353&utm_medium=issues&utm_source=github)** We accept bounties via [Bountysource](https://www.bountysource.com/?utm_campaign=plugin&utm_content=tracker%2F83013353&utm_medium=issues&utm_source=github).
</bountysource-plugin>