### PR TITLE
Support to manual configure the sidebar width of the Gemini Scheme.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -319,6 +319,11 @@ cheers_enabled: true
 # Leave it empty for the default 75% (suggest not less than 1000px)
 #max_content_width: 1000px
 
+# Manual define the sidebar width
+# !!Only available for Gemini Scheme currently
+# Leave it empty for the default 240
+sidebar_width:
+
 # ---------------------------------------------------------------
 # Font Settings
 # - Find fonts on Google Fonts (https://www.google.com/fonts)

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -16,13 +16,13 @@
   top: 0;
   overflow: hidden;
   padding: 0;
-  width: 240px;
+  width: $sidebar-desktop;
   background: white;
   box-shadow: $box-shadow-inner;
   border-radius: $border-radius-inner;
 
   +desktop-large() {
-    .container & { width: 240px; }
+    .container & { width: $sidebar-desktop; }
   }
   +tablet() {
     position: relative;

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -14,7 +14,7 @@
 .sidebar-inner {
 //padding: 20px 10px 0;
   box-sizing: border-box;
-  width: 240px;
+  width: $sidebar-desktop;
   color: $text-color;
   background: white;
   box-shadow: $box-shadow;

--- a/source/css/_variables/Gemini.styl
+++ b/source/css/_variables/Gemini.styl
@@ -7,8 +7,9 @@
 // --------------------------------------------------
 $body-bg-color                    = #eee
 $main-desktop                     = 75%
-$sidebar-desktop                  = 240px
-$content-desktop                  = calc(100% - 252px)
+$sidebar-width                    = hexo-config('sidebar_width') is a 'unit' ? hexo-config('sidebar_width') : 240
+$sidebar-desktop                  = unit($sidebar-width, 'px')
+$content-desktop                  = 'calc(100% - %s)' % unit($sidebar-width + 12, 'px')
 
 // Borders.
 // --------------------------------------------------


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested. **(not affected)**
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?

Related Issue Number(s): #67, https://github.com/iissnan/hexo-theme-next/issues/1980

## What is the new behavior?
Allow the users configure their sidebar width for Gemini Scheme manually.

* Screens with this changes: N/A
* Link to demo site with this changes: https://tsanie.us (with a custom sidebar width: 300px)

### How to use?
In NexT `_config.yml`:
```yml
# Manual define the sidebar width
# !!Only available for Gemini Scheme currently
# Leave it empty for the default 240
sidebar_width: 300
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
