### PR TITLE
Load velocity only if motion is enabled

### DIFF
--- a/layout/_scripts/vendors.swig
+++ b/layout/_scripts/vendors.swig
@@ -17,8 +17,10 @@
   {% set js_vendors.lazyload    = 'jquery_lazyload/jquery.lazyload.js?v=1.9.7' %}
 {% endif %}
 
-{% set js_vendors.velocity    = 'velocity/velocity.min.js?v=1.2.1' %}
-{% set js_vendors.velocity_ui = 'velocity/velocity.ui.min.js?v=1.2.1' %}
+{% if theme.motion.enable %}
+  {% set js_vendors.velocity    = 'velocity/velocity.min.js?v=1.2.1' %}
+  {% set js_vendors.velocity_ui = 'velocity/velocity.ui.min.js?v=1.2.1' %}
+{% endif %}
 
 {% if theme.fancybox %}
   {% set js_vendors.fancybox  = 'fancybox/source/jquery.fancybox.pack.js?v=2.1.5' %}


### PR DESCRIPTION
## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
`velocity` is added in site even if `motion.enable` is false

Issue Number(s): N/A

## What is the new behavior?
`velocity` only added if `motion.enable` is true

* Screens with this changes: N/A
* Link to demo site with this changes: https://blog.maple3142.net/

### How to use?
No need to change anything.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.