### PR TITLE
Keep `description` option only when `seo` enabled.

### DIFF
--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -36,11 +36,7 @@
             {% endif %}
               <p class="site-author-name" itemprop="name">{{ theme.author }}</p>
               <p class="site-description motion-element" itemprop="description">{#
-            #}{% if theme.seo %}{#
-              #}{{ theme.signature }}{#
-            #}{% else %}{#
               #}{{ theme.description }}{#
-            #}{% endif %}{#
             #}</p>
           </div>
 


### PR DESCRIPTION
Remove `signature` option and stay only `description`  for exclude users confused when `seo: true`.