### PR TITLE
Fix justify TOC items in sidebar.

### DIFF
--- a/source/css/_common/components/sidebar/sidebar-toc.styl
+++ b/source/css/_common/components/sidebar/sidebar-toc.styl
@@ -33,7 +33,7 @@
 .post-toc .nav-item {
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: justify;
+  //text-align: justify;
   white-space: nowrap if !hexo-config('toc.wrap');
   line-height: 1.8;
 }


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/16944225/36059135-d7db0742-0e42-11e8-8abc-ff0d29c99ae2.png)

**After:**
![image](https://user-images.githubusercontent.com/16944225/36059141-1efd936a-0e43-11e8-86f0-d6f8d7578eeb.png)

***

Fix to Fix: https://github.com/iissnan/hexo-theme-next/commit/60711f9de5d9c10986f91b5c2922b9d7b894db34#diff-96b203dc237746cf97903c810f062203R36