### PR TITLE
Mist margin settings consistence and a small typo fixed

### DIFF
--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -78,7 +78,7 @@
             #}</time>
             {% endif %}
 
-            {% set date_updated_diff = date(post.date, config_date_format) != date(post.updated, config.date_format) %}
+            {% set date_updated_diff = date(post.date, config.date_format) != date(post.updated, config.date_format) %}
             {% if theme.post_meta.updated_at %}
               {% if !theme.post_meta.updated_diff || theme.post_meta.updated_diff && date_updated_diff %}
                 {% set display_updated = true %}

--- a/source/css/_schemes/Mist/_base.styl
+++ b/source/css/_schemes/Mist/_base.styl
@@ -1,8 +1,5 @@
 // Tags
 // --------------------------------------------------
-h1, h2, h3, h4, h5, h6 { margin: 20px 0 10px; }
-
-p { margin: 0 0 25px 0; }
 
 a { border-bottom-color: $grey-light; }
 


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x ] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x ] Tests for the changes have been added (for bug fixes / features).
   - [x ] Muse | Mist have been tested.
   - [ x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The margins for h1-h6, <p> tags in theme Mist are different from those other themes. It's better to keep the consistency across themes.

Issue Number(s): #146

## What is the new behavior?
Description about this pull, in several words...

Margins in Mist theme are changed to be consistent with other themes.

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
