### PR TITLE
Fixes for GitHub banner option.

### DIFF
--- a/source/css/_common/components/header/github-banner.styl
+++ b/source/css/_common/components/header/github-banner.styl
@@ -1,6 +1,7 @@
 .github-corner {
   scheme = hexo-config('scheme');
   bg_color = unquote(hexo-config('android_chrome_color'));
+  mobile_layout_economy = hexo-config('mobile_layout_economy');
 
   :hover .octo-arm {
     animation:octocat-wave 560ms ease-in-out;
@@ -16,11 +17,8 @@
       transform:rotate(10deg);
     }
   }
-  +mobile() {
+  +tablet-mobile() {
     >svg {
-      if scheme == 'Mist' {
-        top: inherit !important; margin-top: -50px;
-      }
       if (scheme == 'Pisces') || (scheme == 'Gemini') {
         fill: #fff !important;
         color: bg_color !important;
@@ -31,6 +29,19 @@
     }
     .github-corner .octo-arm {
       animation:octocat-wave 560ms ease-in-out;
+    }
+  }
+  +mobile() {
+    >svg {
+      if (scheme == 'Mist') {
+        top: inherit !important;
+        margin-top: -50px;
+        if mobile_layout_economy {
+          +mobile-small() {
+            margin-top: initial;
+          }
+        }
+      }
     }
   }
 

--- a/source/css/_mixins/base.styl
+++ b/source/css/_mixins/base.styl
@@ -34,6 +34,12 @@ mobile() {
   }
 }
 
+tablet-mobile() {
+  @media (max-width: 991px) {
+    {block}
+  }
+}
+
 tablet() {
   @media (min-width: 768px) and (max-width: 991px) {
     {block}


### PR DESCRIPTION
1. Added tablet-mobile mixin template for use < 991px.
2. Fixed GitHub banner color inverting for Pisces/Gemini schemes in tablet styles.
3. Fixed Github banner top alignment with `mobile_style_economy` option for Mist scheme.