### PR TITLE
FIX FIG MARGIN

### DIFF
--- a/source/css/_common/components/post/post-expand.styl
+++ b/source/css/_common/components/post/post-expand.styl
@@ -62,3 +62,4 @@
 }
 
 .posts-expand .post-body .fancybox img { margin: 0 auto 25px; }
+.posts-expand .post-body img { margin: 0 auto 25px; }


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes have been added (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [X] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since the caption position is [lifted it up ( if present ) at least 20px](https://github.com/iissnan/hexo-theme-next/pull/1864). The caption is embedded in bottom of fig which may cause a lap over.

![](https://user-images.githubusercontent.com/8521181/36825056-71874106-1d40-11e8-8da5-5da1a337a01c.png)

## What is the new behavior?

The margin bottom need to set 25px to preserving a space of 5px between the picture and the caption text. 

![qq 20180304220318](https://user-images.githubusercontent.com/8521181/36946426-df4d04dc-1ff7-11e8-84f1-e5249101883f.png)


* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
