### PR TITLE
Fix svg confict in algolia vender

### DIFF
--- a/docs/ALGOLIA-SEARCH.md
+++ b/docs/ALGOLIA-SEARCH.md
@@ -64,7 +64,7 @@ NexT provides Algolia search plugin for index your hexo website content. To use 
       ...
     ```
 
-1. In `next/_config.yml`, turn on `enable` of `algolia_search`. You can adjust the text in `labels` according to your needs.
+1. In `next/_config.yml`, turn on `enable` of `algolia_search`. At the same time, you need to **turn off other search plugins** like Local Search. You can also adjust the text in `labels` according to your needs.
 
     ```yml
     # Algolia Search

--- a/docs/zh-CN/ALGOLIA-SEARCH.md
+++ b/docs/zh-CN/ALGOLIA-SEARCH.md
@@ -62,7 +62,7 @@ NexT 内部提供 Algolia 的搜索功能，要使用此功能请确保所使用
       ...
     ```
 
-1. 更改`主题配置文件`，找到 Algolia Search 配置部分，将 `enable` 改为 `true` 即可，根据需要你可以调整 `labels` 中的文本：
+1. 更改`主题配置文件`，找到 Algolia Search 配置部分，将 `enable` 改为 `true`。同时你需要**关闭**其他搜索插件，如 Local Search 等。你也可以根据需要调整 `labels` 中的文本：
 
     ```yml
     # Algolia Search

--- a/source/css/_common/components/third-party/algolia-search.styl
+++ b/source/css/_common/components/third-party/algolia-search.styl
@@ -1,6 +1,9 @@
 // fix bug using algolia search's CDN
-svg path {
- display: none;
+.ais-search-box--magnifier svg {
+    display: none !important;
+}
+.ais-search-box--reset-wrapper svg {
+    display: none !important;
 }
 
 .algolia-pop-overlay

--- a/source/css/_common/components/third-party/algolia-search.styl
+++ b/source/css/_common/components/third-party/algolia-search.styl
@@ -2,7 +2,7 @@
 .ais-search-box--magnifier svg {
     display: none !important;
 }
-.ais-search-box--reset-wrapper svg {
+.ais-search-box--reset svg {
     display: none !important;
 }
 


### PR DESCRIPTION
In [former file](https://github.com/theme-next/hexo-theme-next/pull/119/files#diff-a8164b1286413219a3653b987a7ebcba), all svg-related element in blog would be blocked leading to the conflict between algolia and svgs.  [Related issue](https://github.com/theme-next/hexo-theme-next/issues/172).

```diff
+svg path {
+ display: none;
+}
```

In this PR, more exact element are found and blocked using algolia CDN , in this way, other svg-related element can be display usually. More related issues about the missing of SVG can be solved.