### PR TITLE
Update codeblock style and add border-radius settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -265,6 +265,11 @@ symbols_count_time:
   awl: 5
   wpm: 200
 
+# codeblock border-radius settings
+# If enabled, the codeblock would be loaded with rounded corners
+codeblock:
+  rounded: false
+
 # Wechat Subscriber
 #wechat_subscriber:
   #enabled: true

--- a/_config.yml
+++ b/_config.yml
@@ -265,10 +265,10 @@ symbols_count_time:
   awl: 5
   wpm: 200
 
-# codeblock border-radius settings
-# If enabled, the codeblock would be loaded with rounded corners
+# Manual define the border radius in codeblock
+# Leave it empty for the default 1
 codeblock:
-  rounded: false
+  border_radius: 
 
 # Wechat Subscriber
 #wechat_subscriber:

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -22,14 +22,12 @@ code {
   color: $code-foreground;
   background: $code-background;
   border-radius: $code-border-radius;
-  font-size $code-font-size;
+  font-size: $code-font-size;
 }
 
 pre {
   @extend $code-block;
   padding: 10px;
-  if hexo-config('codeblock.rounded') { border-radius: 5px;}
-
   code {
     padding: 0;
     color: $highlight-foreground;
@@ -40,8 +38,9 @@ pre {
 
 .highlight {
   @extend $code-block;
-  if hexo-config('codeblock.rounded') { border-radius: 5px;}
-  if not hexo-config('codeblock.rounded'){ border-radius: 1px;}
+  // Read values from NexT config and set they as local variables to use as string variables (in any CSS section). 
+  hexo-config('codeblock.border_radius') is a 'unit' ? (cbradius = unit(hexo-config('codeblock.border_radius'), px)) : (cbradius = 1px) 
+  border-radius: cbradius;
 
   pre {
     border: none;
@@ -68,7 +67,7 @@ pre {
     margin-bottom: 1em;
 	margin: 0em;
 	padding: 0.5em;
-	background: #eee;
+	background: $gainsboro;
 	border-bottom: 1px solid #e9e9e9;
 
     a {

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -65,10 +65,10 @@ pre {
     color: $highlight-foreground;
     line-height: 1em;
     margin-bottom: 1em;
-	margin: 0em;
-	padding: 0.5em;
-	background: $gainsboro;
-	border-bottom: 1px solid #e9e9e9;
+    margin: 0em;
+    padding: 0.5em;
+    background: $code-background;
+    border-bottom: 1px solid #e9e9e9;
 
     a {
       float: right;

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -28,6 +28,7 @@ code {
 pre {
   @extend $code-block;
   padding: 10px;
+  if hexo-config('codeblock.rounded') { border-radius: 5px;}
 
   code {
     padding: 0;
@@ -39,7 +40,8 @@ pre {
 
 .highlight {
   @extend $code-block;
-  border-radius: 1px
+  if hexo-config('codeblock.rounded') { border-radius: 5px;}
+  if not hexo-config('codeblock.rounded'){ border-radius: 1px;}
 
   pre {
     border: none;
@@ -64,6 +66,10 @@ pre {
     color: $highlight-foreground;
     line-height: 1em;
     margin-bottom: 1em;
+	margin: 0em;
+	padding: 0.5em;
+	background: #eee;
+	border-bottom: 1px solid #e9e9e9;
 
     a {
       float: right;


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [X] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [X] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Optimize the visual style of codeblock
- Add the option of border-radius of codeblock. if `codeblock.rounded=false`, the codeblock would be loaded with rounded corner.

![1](https://user-images.githubusercontent.com/8521181/37695148-ffb66bce-2d07-11e8-913b-53cfbc359e7f.png)


Issue Number(s): N/A

## What is the new behavior?

![2](https://user-images.githubusercontent.com/8521181/37695152-060f2c7c-2d08-11e8-8269-6f9a01b07a8d.png)

`codeblock.rounded=true`

![3](https://user-images.githubusercontent.com/8521181/37695154-07a64be2-2d08-11e8-9187-1908ccfe391e.png)


* Screens with this changes: N/A
* Link to demo site with this changes: http://test.saili.science/posts/codeblock-test/

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [ ] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
