### PR TITLE
Added `footer.powered.version` option to display Hexo version in footer.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ footer:
   #since: 2015
 
   # Icon between year and copyright info.
-  icon: 
+  icon:
     # Icon name in fontawesome, see: https://fontawesome.com/v4.7.0/icons
     # `heart` is recommended with animation in red (#ff0000).
     name: user
@@ -75,8 +75,11 @@ footer:
   # If not defined, will be used `author` from Hexo main config.
   copyright:
   # -------------------------------------------------------------
-  # Hexo link (Powered by Hexo).
-  powered: true
+  powered:
+    # Hexo link (Powered by Hexo).
+    enable: true
+    # Version info of Hexo after Hexo link (vX.X.X).
+    version: true
 
   theme:
     # Theme & scheme info link (Theme - NexT.scheme).
@@ -275,7 +278,7 @@ symbols_count_time:
 # Manual define the border radius in codeblock
 # Leave it empty for the default 1
 codeblock:
-  border_radius: 
+  border_radius:
 
 # Wechat Subscriber
 #wechat_subscriber:

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -2,7 +2,7 @@
 #}{% set current = date(Date.now(), "YYYY") %}{#
 #}&copy; {% if theme.footer.since and theme.footer.since != current %}{{ theme.footer.since }} &mdash; {% endif %}{#
 #}<span itemprop="copyrightYear">{{ current }}</span>
-  <span class="with-love" id="animate"> 
+  <span class="with-love" id="animate">
     <i class="fa fa-{{ theme.footer.icon.name }}"></i>
   </span>
   <span class="author" itemprop="copyrightHolder">{{ theme.footer.copyright || config.author }}</span>
@@ -13,7 +13,7 @@
       <i class="fa fa-area-chart"></i>
     </span>
     {% if theme.symbols_count_time.item_text_total %}
-      <span class="post-meta-item-text">{{ __('post.total_symbols')  + __('symbol.colon') }}</span>
+      <span class="post-meta-item-text">{{ __('post.total_symbols') + __('symbol.colon') }}</span>
     {% endif %}
     <span title="{{ __('post.total_symbols') }}">{#
     #}{{ symbolsCountTotal(site) }}{#
@@ -26,7 +26,7 @@
       <i class="fa fa-coffee"></i>
     </span>
     {% if theme.symbols_count_time.item_text_total %}
-      <span class="post-meta-item-text">{{ __('post.total_time')  + __('symbol.colon') }}</span>
+      <span class="post-meta-item-text">{{ __('post.total_time') + __('symbol.colon') }}</span>
     {% endif %}
     <span title="{{ __('post.total_time') }}">{#
     #}{{ symbolsTimeTotal(site, theme.symbols_count_time.awl, theme.symbols_count_time.wpm) }}{#
@@ -40,7 +40,7 @@
 
 {% if theme.footer.powered %}
   <div class="powered-by">{#
-  #}{{ __('footer.powered', '<a class="theme-link" target="_blank"' + nofollow + ' href="https://hexo.io">Hexo</a>') }}{#
+  #}{{ __('footer.powered', '<a class="theme-link" target="_blank"' + nofollow + ' href="https://hexo.io">Hexo</a>') }}{% if theme.footer.powered.version %} v{{ hexo_version() }}{% endif %}{#
 #}</div>
 {% endif %}
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -13,3 +13,7 @@ hexo.extend.helper.register('item_active', function(path, className) {
   }
   return result;
 });
+
+hexo.extend.helper.register('hexo_version', function() {
+  return this.env.version;
+});


### PR DESCRIPTION
## Breaking Changes

### Old configuration:

```diff
footer:
-  powered: true
```

### New configuration:

```yml
footer:
  powered:
    # Hexo link (Powered by Hexo).
    enable: true
    # Version info of Hexo after Hexo link (vX.X.X).
    version: true
```

## How it looks?

![image](https://user-images.githubusercontent.com/16944225/38306332-e4c13b20-3818-11e8-9f78-9cc6fda155d7.png)