### PR TITLE
Add date_time_merge filed into post_meta

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -264,6 +264,8 @@ post_meta:
   updated_at: false
   # Only show 'updated' if different from 'created'.
   updated_diff: false
+  # If true, post's time format will be hexo config's date_format + ' ' + time_format.
+  date_time_merge: false
   categories: true
 
 # Post wordcount display settings
@@ -951,3 +953,4 @@ images: images
 
 # Theme version
 version: 6.1.0
+

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -66,6 +66,12 @@
 
         <div class="post-meta">
           <span class="post-time">
+            {% if theme.post_meta.date_time_merge %}
+                {% set datetime_format = config.date_format + ' ' + config.time_format %}
+            {% else %}
+                {% set datetime_format = config.date_format %}
+            {% endif %}
+
             {% if theme.post_meta.created_at %}
               <span class="post-meta-item-icon">
                 <i class="fa fa-calendar-o"></i>
@@ -74,11 +80,11 @@
                 <span class="post-meta-item-text">{{ __('post.posted') }}</span>
               {% endif %}
               <time title="{{ __('post.created') }}" itemprop="dateCreated datePublished" datetime="{{ moment(post.date).format() }}">{#
-              #}{{ date(post.date, config.date_format) }}{#
+              #}{{ date(post.date, datetime_format) }}{#
             #}</time>
             {% endif %}
 
-            {% set date_updated_diff = date(post.date, config.date_format) != date(post.updated, config.date_format) %}
+            {% set date_updated_diff = date(post.date, datetime_format) != date(post.updated, datetime_format) %}
             {% if theme.post_meta.updated_at %}
               {% if !theme.post_meta.updated_diff || theme.post_meta.updated_diff && date_updated_diff %}
                 {% set display_updated = true %}
@@ -97,7 +103,7 @@
                 <span class="post-meta-item-text">{{ __('post.modified') + __('symbol.colon') }}</span>
               {% endif %}
               <time title="{{ __('post.modified') }}" itemprop="dateModified" datetime="{{ moment(post.updated).format() }}">{#
-              #}{{ date(post.updated, config.date_format) }}{#
+              #}{{ date(post.updated, datetime_format) }}{#
             #}</time>
             {% endif %}
           </span>


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
```yml
Without origin hexo and NexT _config.yml  
```  
In post time area, only display with date. like below
> Posted on 2018-04-10

## What is the new behavior?
```yml  
# hexo _config.yml
date_format: YYYY-MM-DD
time_format: HH:mm:ss
# NexT _config.yml
post_meta:
  ...
  date_time_merge: true
  ...
```  
It can merge hexo config's date and time format together. like:
> Posted on 2018-04-10 19:44:03

* Screens with this changes: N/A
* Link to demo site with this changes: [MyGithubPage](https://jackey8616.github.io)

### How to use?
In NexT `_config.yml`:
```yml  
post_meta:
  ...
  date_time_merge: true
  ...
```
and everything worked.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.