### PR TITLE
Added support for hexo-symbols-count-time v0.4.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -274,8 +274,8 @@ symbols_count_time:
   separated_meta: true
   item_text_post: true
   item_text_total: false
-  awl: 5
-  wpm: 200
+  awl: 4
+  wpm: 275
 
 # Manual define the border radius in codeblock
 # Leave it empty for the default 1

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -34,10 +34,6 @@ post:
   toc_empty: This post does not have a Table of Contents
   views: Views
   comments_count: Comments
-  symbols_count: Symbols count in article
-  symbols_time: Reading time
-  total_symbols: Symbols count total
-  total_time: Reading time total
   related_posts: Related Posts
   copyright:
     author: Post author
@@ -107,3 +103,10 @@ accessibility:
   nav_toggle: Toggle navigation bar
   prev_page: Previous page
   next_page: Next page
+
+symbols_count_time:
+  count: Symbols count in article
+  count_total: Symbols count total
+  time: Reading time
+  time_total: Reading time total
+  time_minutes: mins.

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -248,9 +248,9 @@
                   <i class="fa fa-file-word-o"></i>
                 </span>
                 {% if theme.symbols_count_time.item_text_post %}
-                  <span class="post-meta-item-text">{{ __('post.symbols_count') + __('symbol.colon') }}</span>
+                  <span class="post-meta-item-text">{{ __('symbols_count_time.count') + __('symbol.colon') }}</span>
                 {% endif %}
-                <span title="{{ __('post.symbols_count') }}">{#
+                <span title="{{ __('symbols_count_time.count') }}">{#
                 #}{{ symbolsCount(post.content) }}{#
               #}</span>
               {% endif %}
@@ -264,10 +264,10 @@
                   <i class="fa fa-clock-o"></i>
                 </span>
                 {% if theme.symbols_count_time.item_text_post %}
-                  <span class="post-meta-item-text">{{ __('post.symbols_time') }}&asymp;</span>
+                  <span class="post-meta-item-text">{{ __('symbols_count_time.time') }} &asymp;</span>
                 {% endif %}
-                <span title="{{ __('post.symbols_time') }}">{#
-                #}{{ symbolsTime(post.content, theme.symbols_count_time.awl, theme.symbols_count_time.wpm) }}{#
+                <span title="{{ __('symbols_count_time.time') }}">{#
+                #}{{ symbolsTime(post.content, theme.symbols_count_time.awl, theme.symbols_count_time.wpm, __('symbols_count_time.time_minutes')) }}{#
               #}</span>
               {% endif %}
             </div>

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -13,9 +13,9 @@
       <i class="fa fa-area-chart"></i>
     </span>
     {% if theme.symbols_count_time.item_text_total %}
-      <span class="post-meta-item-text">{{ __('post.total_symbols') + __('symbol.colon') }}</span>
+      <span class="post-meta-item-text">{{ __('symbols_count_time.count_total') + __('symbol.colon') }}</span>
     {% endif %}
-    <span title="{{ __('post.total_symbols') }}">{#
+    <span title="{{ __('symbols_count_time.count_total') }}">{#
     #}{{ symbolsCountTotal(site) }}{#
   #}</span>
   {% endif %}
@@ -26,10 +26,10 @@
       <i class="fa fa-coffee"></i>
     </span>
     {% if theme.symbols_count_time.item_text_total %}
-      <span class="post-meta-item-text">{{ __('post.total_time') + __('symbol.colon') }}</span>
+      <span class="post-meta-item-text">{{ __('symbols_count_time.time_total')}} &asymp;</span>
     {% endif %}
-    <span title="{{ __('post.total_time') }}">{#
-    #}{{ symbolsTimeTotal(site, theme.symbols_count_time.awl, theme.symbols_count_time.wpm) }}{#
+    <span title="{{ __('symbols_count_time.time_total') }}">{#
+    #}{{ symbolsTimeTotal(site, theme.symbols_count_time.awl, theme.symbols_count_time.wpm, __('symbols_count_time.time_minutes')) }}{#
   #}</span>
   {% endif %}
 </div>


### PR DESCRIPTION
1. Modified default settings: `AWL = 4`; `WPM = 275`.
2. Added suffix as string parameter if time to read less then 60 minutes. Default: `mins.`
3. Refactored language translates.

## Plugin tests

```js
$ npm test

  Hexo Symbols Count Time
    Test symbolsCount function & check should / expect / assert
      ✓ should - 22
      ✓ expect - 22
      ✓ assert - 22
    Test symbolsCount < 999
      ✓ Symbols: 569 => 569
    Test symbolsCount > 999
      ✓ Symbols: 1337 => 1.3k
    Test symbolsCount > 9999
      ✓ Symbols: 10703 => 11k
    Test symbolsCount & symbolsTime (awl / wpm)
      ✓ Symbols: (symbolsCount = 90)
      ✓ Time: [awl = 5, wpm = 200] => 1 mins.
      ✓ Time: [awl = 5, wpm = 5] => 4 mins.
      ✓ Time: [awl = 1, wpm = 50] => 2 mins.
    Test symbolsTime (< 58 minutes / > 1:08)
      ✓ Time: 64218 = 58 => 58 minutes
      ✓ Time: 74921 = 68 => 1:08

```