### PR TITLE
fix hexo-symbols-count-time not working

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -274,6 +274,8 @@ post_meta:
 symbols_count_time:
   symbols: true 
   time: true 
+  total_symbols: true
+  total_time: true
   separated_meta: true
   item_text_post: true
   item_text_total: false

--- a/_config.yml
+++ b/_config.yml
@@ -272,6 +272,8 @@ post_meta:
 # Post wordcount display settings
 # Dependencies: https://github.com/theme-next/hexo-symbols-count-time
 symbols_count_time:
+  symbols: true 
+  time: true 
   separated_meta: true
   item_text_post: true
   item_text_total: false


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes have been added (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
[_config.yml](https://github.com/theme-next/hexo-theme-next/blob/v6.2.0/_config.yml#L274-L279) missing necessary parameters cause `hexo-symbols-count-time` not working.
`symbols` and `time` always false in this [file](https://github.com/theme-next/hexo-theme-next/blob/v6.2.0/layout/_macro/post.swig#L247)


Issue Number(s): N/A

## What is the new behavior?
Description about this pull, in several words...
add `symbols` and `time` parameter in `_config.yml`.

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
symbols_count_time:
  symbols: true 
  time: true 
  separated_meta: true
  item_text_post: true
  item_text_total: true
  awl: 2
  wpm: 300
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.