### PR TITLE
Allow customized copyright contents

### DIFF
--- a/layout/_macro/post-copyright.swig
+++ b/layout/_macro/post-copyright.swig
@@ -9,6 +9,6 @@
   </li>
   <li class="post-copyright-license">
     <strong>{{ __('post.copyright.license_title') + __('symbol.colon') }} </strong>{#
-  #}{{ __('post.copyright.license_content', theme.post_copyright.license) }}{#
+  #}{{ post.copyright | default(__('post.copyright.license_content', theme.post_copyright.license)) }}{#
 #}</li>
 </ul>


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This theme does not support customized copyright contents.

## What is the new behavior?
Use can defined there copyright contents in post

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In post, user can use `copyright` in front-matter block to define their own copyright contents

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
