### PR TITLE
fixed text font of the Mist scheme is smaller than other schemes on mobile phone

### DIFF
--- a/source/css/_schemes/Mist/_posts-expanded.styl
+++ b/source/css/_schemes/Mist/_posts-expanded.styl
@@ -28,7 +28,7 @@
   .post-title:hover:before { background: $black-deep; }
 
   .post-body {
-    +mobile() { font-size: $font-size-small; }
+    +mobile() { font-size: $font-size-base; }
   }
 
   .post-body img { margin: 0; }


### PR DESCRIPTION

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With the default font size(14px), text font of the Mist scheme is smaller than other schemes on mobile phone, and is also smaller than release 5.1.3。

Issue Number(s): #245 #38 

## What is the new behavior?
changed font-size from $font-size-small to $font-size-base, 12px -> 14px