### PR TITLE
support copy result

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -283,7 +283,10 @@ codeblock:
   # Leave it empty for the default 1
   border_radius:
   # Add copy button on codeblock
-  copy_button: false
+  copy_button:
+    enable: false
+    # Show text copy result
+    show_result: false
 
 # Wechat Subscriber
 #wechat_subscriber:

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -35,6 +35,8 @@ post:
   comments_count: Comments
   related_posts: Related Posts
   copy_button: Copy
+  copy_success: Copied
+  copy_failure: Copy failed
   copyright:
     author: Post author
     link: Post link

--- a/languages/zh-TW.yml
+++ b/languages/zh-TW.yml
@@ -33,6 +33,8 @@ post:
   comments_count: 評論數
   related_posts: 相關文章
   copy_button: 複製
+  copy_success: 複製成功
+  copy_failure: 複製失敗
   copyright:
     author: 作者
     link: 文章連結

--- a/layout/_third-party/copy-code.swig
+++ b/layout/_third-party/copy-code.swig
@@ -1,59 +1,70 @@
-{% if theme.codeblock.copy_button %}
+{% if theme.codeblock.copy_button.enable %}
   <style>
-      .copy-btn {
-          display: inline-block;
-          padding: 6px 12px;
-          font-size: 13px;
-          font-weight: 700;
-          line-height: 20px;
-          color: #333;
-          white-space: nowrap;
-          vertical-align: middle;
-          cursor: pointer;
-          background-color: #eee;
-          background-image: linear-gradient(#fcfcfc, #eee);
-          border: 1px solid #d5d5d5;
-          border-radius: 3px;
-          user-select: none;
-      }
+    .copy-btn {
+      display: inline-block;
+      padding: 6px 12px;
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 20px;
+      color: #333;
+      white-space: nowrap;
+      vertical-align: middle;
+      cursor: pointer;
+      background-color: #eee;
+      background-image: linear-gradient(#fcfcfc, #eee);
+      border: 1px solid #d5d5d5;
+      border-radius: 3px;
+      user-select: none;
+      outline: 0;
+    }
 
-      .highlight-wrap .copy-btn {
-          transition: opacity .3s ease-in-out;
-          opacity: 0;
-          padding: 2px 6px;
-          position: absolute;
-          right: 4px;
-          top: 8px;
-      }
+    .highlight-wrap .copy-btn {
+      transition: opacity .3s ease-in-out;
+      opacity: 0;
+      padding: 2px 6px;
+      position: absolute;
+      right: 4px;
+      top: 8px;
+    }
 
-      .highlight-wrap:hover .copy-btn,
-      .highlight-wrap .copy-btn:focus {
-          opacity: 1
-      }
+    .highlight-wrap:hover .copy-btn,
+    .highlight-wrap .copy-btn:focus {
+      opacity: 1
+    }
 
-      .highlight-wrap {
-          position: relative;
-      }
+    .highlight-wrap {
+      position: relative;
+    }
   </style>
   <script>
-      $('.highlight').each(function(i, e) {
-          var $wrap = $('<div>').addClass('highlight-wrap')
-          $(e).after($wrap)
-          $wrap.append($('<button>').addClass('copy-btn').append('{{__("post.copy_button")}}').on('click', function(e) {
-              var code = $(e.target).parent().find('.code').find('.line').map(function(i, e) {
-                  return $(e).text()
-              }).toArray().join('\n')
-              var ta = document.createElement('textarea')
-              document.body.appendChild(ta)
-              ta.style.position = 'fixed'
-              ta.style.top = 0
-              ta.style.left = 0
-              ta.value = code
-              ta.select()
-              ta.focus()
-              document.execCommand('copy')
-              document.body.removeChild(ta)
-          })).append(e)
-      })
+    $('.highlight').each(function (i, e) {
+      var $wrap = $('<div>').addClass('highlight-wrap')
+      $(e).after($wrap)
+      $wrap.append($('<button>').addClass('copy-btn').append('{{__("post.copy_button")}}').on('click', function (e) {
+        var code = $(this).parent().find('.code').find('.line').map(function (i, e) {
+          return $(e).text()
+        }).toArray().join('\n')
+        var ta = document.createElement('textarea')
+        document.body.appendChild(ta)
+        ta.style.position = 'absolute'
+        ta.style.top = '0px'
+        ta.style.left = '0px'
+        ta.value = code
+        ta.select()
+        ta.focus()
+        var result = document.execCommand('copy')
+        document.body.removeChild(ta)
+        {% if theme.codeblock.copy_button.show_result %}
+          if(result)$(this).text('{{__("post.copy_success")}}')
+          else $(this).text('{{__("post.copy_failure")}}')
+        {% endif %}
+        $(this).blur()
+      })).on('mouseleave', function (e) {
+        var $b = $(this).find('.copy-btn')
+        setTimeout(function () {
+          $b.text('{{__("post.copy_button")}}')
+        }, 300)
+      }).append(e)
+    })
   </script>
 {% endif %}


### PR DESCRIPTION
## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Click on the copy button, and copy button doesn't change.

Issue Number(s): #276 

## What is the new behavior?
Click on the copy button, and copy button show copy result if `show_result` is enabled.

* Screens with this changes: N/A
* Link to demo site with this changes: https://blog.maple3142.net/2018/05/05/how-to-download-youtube-video/

### How to use?
In NexT `_config.yml`:
```yml
codeblock:
  # Manual define the border radius in codeblock
  # Leave it empty for the default 1
  border_radius:
  # Add copy button on codeblock
  copy_button:
    enable: true
    # Show text copy result
    show_result: true
```

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.

```yml
codeblock:
  copy_button: true
```
to
```yml
codeblock:
  copy_button:
    enable: true
    show_result: true
```
