### PR TITLE
Fix the post date display bug and Updated the post meta display

### DIFF
--- a/languages/en.yml
+++ b/languages/en.yml
@@ -20,12 +20,12 @@ sidebar:
   toc: Table of Contents
 
 post:
-  posted: Posted on
-  edited: Edited on
+  posted: Posted
+  edited: Last updated
   created: Created
   modified: Modified
   edit: Edit this post
-  in: In
+  in: Filed as
   more: more
   read_more: Read more
   untitled: Untitled

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -20,12 +20,12 @@ sidebar:
   toc: Table of Contents
 
 post:
-  posted: Posted
-  edited: Last updated
+  posted: Posted on
+  edited: Edited on
   created: Created
   modified: Modified
   edit: Edit this post
-  in: Filed as
+  in: In
   more: more
   read_more: Read more
   untitled: Untitled

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -83,7 +83,7 @@
                 <i class="fa fa-calendar-o"></i>
               </span>
               {% if theme.post_meta.item_text %}
-                <span class="post-meta-item-text">{{ __('post.posted') + __('symbol.colon') }}</span>
+                <span class="post-meta-item-text">{{ __('post.posted') }}</span>
               {% endif %}
 
               {% if !date_diff && time_diff && theme.post_meta.updated_at.enabled && theme.post_meta.updated_at.another_day %}
@@ -109,7 +109,7 @@
                   <i class="fa fa-calendar-check-o"></i>
                 </span>
                 {% if theme.post_meta.item_text %}
-                  <span class="post-meta-item-text">{{ __('post.edited') + __('symbol.colon') }}</span>
+                  <span class="post-meta-item-text">{{ __('post.edited') }}</span>
                 {% endif %}
                 <time title="{{ __('post.modified') + __('symbol.colon') + full_date(post.updated) }}" itemprop="dateModified" datetime="{{ moment(post.updated).format() }}">{#
                 #}{{ date(post.updated) -}}
@@ -127,7 +127,7 @@
                 <i class="fa fa-folder-o"></i>
               </span>
               {% if theme.post_meta.item_text %}
-                <span class="post-meta-item-text">{{ __('post.in') + __('symbol.colon') }}</span>
+                <span class="post-meta-item-text">{{ __('post.in') }}</span>
               {% endif %}
               {% for cat in post.categories %}
                 <span itemprop="about" itemscope itemtype="http://schema.org/Thing">{#

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -83,7 +83,7 @@
                 <i class="fa fa-calendar-o"></i>
               </span>
               {% if theme.post_meta.item_text %}
-                <span class="post-meta-item-text">{{ __('post.posted') }}</span>
+                <span class="post-meta-item-text">{{ __('post.posted') + __('symbol.colon') }}</span>
               {% endif %}
 
               {% if !date_diff && time_diff && theme.post_meta.updated_at.enabled && theme.post_meta.updated_at.another_day %}
@@ -109,14 +109,10 @@
                   <i class="fa fa-calendar-check-o"></i>
                 </span>
                 {% if theme.post_meta.item_text %}
-                  <span class="post-meta-item-text">{{ __('post.edited') }}</span>
+                  <span class="post-meta-item-text">{{ __('post.edited') + __('symbol.colon') }}</span>
                 {% endif %}
                 <time title="{{ __('post.modified') + __('symbol.colon') + full_date(post.updated) }}" itemprop="dateModified" datetime="{{ moment(post.updated).format() }}">{#
-                #}{% if date_diff -%}
-                    {{- date(post.updated) -}}
-                  {%- else -%}
-                    {{- time(post.updated) -}}
-                  {%- endif -%}
+                #}{{ date(post.updated) -}}
                 </time>
               {% endif %}
             {% endif %}
@@ -131,7 +127,7 @@
                 <i class="fa fa-folder-o"></i>
               </span>
               {% if theme.post_meta.item_text %}
-                <span class="post-meta-item-text">{{ __('post.in') }}</span>
+                <span class="post-meta-item-text">{{ __('post.in') + __('symbol.colon') }}</span>
               {% endif %}
               {% for cat in post.categories %}
                 <span itemprop="about" itemscope itemtype="http://schema.org/Thing">{#
@@ -274,7 +270,7 @@
                   <i class="fa fa-clock-o"></i>
                 </span>
                 {% if theme.symbols_count_time.item_text_post %}
-                  <span class="post-meta-item-text">{{ __('symbols_count_time.time') }} &asymp;</span>
+                  <span class="post-meta-item-text">{{ __('symbols_count_time.time') + __('symbol.colon') }}</span>
                 {% endif %}
                 <span title="{{ __('symbols_count_time.time') }}">{#
                 #}{{ symbolsTime(post.content, theme.symbols_count_time.awl, theme.symbols_count_time.wpm, __('symbols_count_time.time_minutes')) }}{#

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -270,7 +270,7 @@
                   <i class="fa fa-clock-o"></i>
                 </span>
                 {% if theme.symbols_count_time.item_text_post %}
-                  <span class="post-meta-item-text">{{ __('symbols_count_time.time') + __('symbol.colon') }}</span>
+                  <span class="post-meta-item-text">{{ __('symbols_count_time.time') }} &asymp;</span>
                 {% endif %}
                 <span title="{{ __('symbols_count_time.time') }}">{#
                 #}{{ symbolsTime(post.content, theme.symbols_count_time.awl, theme.symbols_count_time.wpm, __('symbols_count_time.time_minutes')) }}{#


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Since its static blog, when the date goes on, the non-display date in post meta seems unusual.

![image](https://user-images.githubusercontent.com/8521181/40104009-bf744ea0-5921-11e8-83d4-ecf77c98024e.png)

Issue Number(s): https://github.com/theme-next/hexo-theme-next/pull/228#issuecomment-389430077

## What is the new behavior?

- Use `date(post.updated)` when `created_at=false` & `date(post.date) = date(post.updated)`
- ~~nominalize the `posted` (posted time), `edited` (modified time), `in` (post folder ) in post meta for unification and convenient translation.~~

* Screens with this changes: N/A
* Link to demo site with this changes: https://test.saili.science/

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
