### PR TITLE
add math.cdn to head.swig

### DIFF
--- a/layout/_partials/head/head.swig
+++ b/layout/_partials/head/head.swig
@@ -131,6 +131,16 @@
   };
 </script>
 
+{% if theme.math.enable %}
+  {% if theme.math.per_page %}
+    {% if theme.math.engine == 'katex' %}
+      <link rel="stylesheet" href="{{ theme.math.katex.cdn }}">
+    {% elseif theme.math.engine == 'mathjax' %}
+      <link rel="stylesheet" href="{{ theme.math.mathjax.cdn }}">
+    {% endif %}
+  {% endif %}
+{% endif %}
+
 {% if theme.custom_file_path.head %}
   {% set custom_head = '../../../../../' + theme.custom_file_path.head %}
 {% else %}


### PR DESCRIPTION
The original file "head.swig" is not included math.cdn.
The generated page file does not load the CDN.
The change add the CDN load.