### PR TITLE
add refer for livere

### DIFF
--- a/layout/_third-party/comments/livere.swig
+++ b/layout/_third-party/comments/livere.swig
@@ -2,6 +2,9 @@
 
   {% if page.comments and theme.livere_uid %}
     <script type="text/javascript">
+      window.livereOptions = {
+        refer: '{{ page.path }}'
+      };
       (function(d, s) {
         var j, e = d.getElementsByTagName(s)[0];
         if (typeof LivereTower === 'function') { return; }


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->
## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you use LiveRe comment box, LiveRe uses full URL as its identifier by default. Consider these 2 URLs:
```
example.com/my_article/
example.com/my_article/index.html
```
These two URLs actually  access to the same page, but LiveRe will treat them differently, so you won't see same comments on these two URLs.

## What is the new behavior?
I added `refer` to be equal to `page.path` according to the [official documentation](https://101.livere.co.kr/livere9com/pdf/guide/LiveRe_City_Chn.pdf). Since this way is also be used in disqus when defining identifier:
https://github.com/theme-next/hexo-theme-next/blob/79932de3431db6c7a2c306e980dc78e77af4dfb3/layout/_third-party/comments/disqus.swig#L11

I believe it can fix this bug.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

