### PR TITLE
Fix bugs where images other than avatars will also rotate

### DIFF
--- a/source/css/_common/components/sidebar/sidebar-author.styl
+++ b/source/css/_common/components/sidebar/sidebar-author.styl
@@ -23,7 +23,7 @@ if hexo-config('avatar.rotated') {
 }
 }
 
-img:hover {
+.site-author-image img:hover {
   -webkit-transform: rotateZ(360deg);
   -moz-transform: rotateZ(360deg);
   -ms-transform: rotate(360deg);


### PR DESCRIPTION
## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
When using [Valine](https://valine.js.org), the image in the comment area will also rotate, even if `avatar.rotated : false` in `_config.yml`.

for instance : http://www.zhaojun.im/hexo-valine-admin/#comments

## What is the new behavior?

Only the avatar can be rotated, it will not affect the other.


## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.