### PR TITLE
修复配置文件里面的google calendar无法使用

### DIFF
--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -109,6 +109,7 @@
   {% include '_third-party/analytics/lean-analytics.swig' %}
   {% include '_third-party/analytics/firestore.swig' %}
   {% include '_third-party/seo/baidu-push.swig' %}
+  {% include '_third-party/schedule.swig' %}
   {% include '_third-party/math/index.swig' %}
   {% include '_third-party/needsharebutton.swig' %}
   {% include '_third-party/rating.swig' %}

--- a/layout/page.swig
+++ b/layout/page.swig
@@ -8,6 +8,8 @@
     #}{{ __('title.category') + page_title_suffix }}{#
   #}{% elif page.type === "tags" and not page.title %}{#
     #}{{ __('title.tag') + page_title_suffix }}{#
+  #}{% elif page.type === "schedule" and not page.title %}{#
+    #}{{ __('title.schedule') + page_title_suffix }}{#
   #}{% else %}{#
     #}{{ page.title + page_title_suffix }}{#
   #}{% endif %}{#
@@ -56,6 +58,13 @@
             </div>
             <div class="category-all">
               {{ list_categories() }}
+            </div>
+          </div>
+        {% elif page.type === 'schedule' %}
+          <div class="schedule">
+            <div id="schedule">
+              <ul id="event-list">
+              </ul>
             </div>
           </div>
         {% else %}


### PR DESCRIPTION
修复配置文件里面的google calendar无法使用，好像是新版去掉这个功能了，再次打开它了。
![image](https://user-images.githubusercontent.com/7813511/45199600-2d0a6400-b29f-11e8-930c-5365b5bf86ea.png)
