### PR TITLE
Fixes for sidebar in Pisces / Gemini schemes.

### DIFF
--- a/source/css/_common/scaffolding/mobile.styl
+++ b/source/css/_common/scaffolding/mobile.styl
@@ -110,11 +110,6 @@
     }
   }
 
-    // For footer alignment.
-    .footer-inner {
-      margin: 20px 10px;
-    }
-
   // Need to refactor into flex.
   .post-nav {
     padding-bottom: 2px;

--- a/source/css/_common/scaffolding/mobile.styl
+++ b/source/css/_common/scaffolding/mobile.styl
@@ -76,6 +76,11 @@
       padding: 0 18px;
     }
 
+    // For external links alignment.
+    > span.exturl {
+      margin-left: 18px;
+    }
+
     // Rewrite paddings & margins inside tags.
     .note > p, .tabs .tab-content .tab-pane > p {
       padding: 0 5px;
@@ -104,6 +109,11 @@
       padding: 10px 10px 0 10px !important;
     }
   }
+
+    // For footer alignment.
+    .footer-inner {
+      margin: 20px 10px;
+    }
 
   // Need to refactor into flex.
   .post-nav {

--- a/source/js/src/schemes/pisces.js
+++ b/source/js/src/schemes/pisces.js
@@ -39,22 +39,25 @@ $(document).ready(function() {
     setSidebarMarginTop(headerOffset).css({ 'margin-left': 'initial' });
   }
 
-  function recalculateAffixPosition() {
+  /* function recalculateAffixPosition() {
     $(window).off('.affix');
     sidebarInner.removeData('bs.affix').removeClass('affix affix-top affix-bottom');
     initAffix();
-  }
+  } */
 
   function resizeListener() {
     var mql = window.matchMedia('(min-width: 991px)');
     mql.addListener(function(e) {
       if (e.matches) {
-        recalculateAffixPosition();
+        //recalculateAffixPosition();
+        sidebarInner.affix('checkPosition');
       }
     });
   }
 
   initAffix();
   resizeListener();
+  // Fixed wrong top alignment if page scrolled to the bottom after cleared cache and browser refresh.
+  sidebarInner.affix('checkPosition');
 
 });

--- a/source/js/src/utils.js
+++ b/source/js/src/utils.js
@@ -110,9 +110,14 @@ NexT.utils = NexT.$u = {
       $('#scrollpercent>span').html(scrollPercentMaxed);
     }
 
-    // For init back to top in sidebar if page was scrolled.
-    $(document).ready(function() { initBackToTop(); });
-    $(window).on('scroll', function() { initBackToTop(); });
+    // For init back to top in sidebar if page was already scrolled.
+    $(document).ready(function() {
+      initBackToTop();
+    });
+
+    $(window).on('scroll', function() {
+      initBackToTop();
+    });
 
     $top.on('click', function() {
       $('body').velocity('scroll');

--- a/source/js/src/utils.js
+++ b/source/js/src/utils.js
@@ -99,7 +99,7 @@ NexT.utils = NexT.$u = {
     var THRESHOLD = 50;
     var $top = $('.back-to-top');
 
-    $(window).on('scroll', function() {
+    function initBackToTop() {
       $top.toggleClass('back-to-top-on', window.pageYOffset > THRESHOLD);
 
       var scrollTop = $(window).scrollTop();
@@ -108,7 +108,11 @@ NexT.utils = NexT.$u = {
       var scrollPercentRounded = Math.round(scrollPercent * 100);
       var scrollPercentMaxed = scrollPercentRounded > 100 ? 100 : scrollPercentRounded;
       $('#scrollpercent>span').html(scrollPercentMaxed);
-    });
+    }
+
+    // For init back to top in sidebar if page was scrolled.
+    $(document).ready(function() { initBackToTop(); });
+    $(window).on('scroll', function() { initBackToTop(); });
 
     $top.on('click', function() {
       $('body').velocity('scroll');


### PR DESCRIPTION
1. If scrolled to bottom, sidebar cannot automatically set to top (#114).
2. If scrolled and `b2t` & `scrollpercent` enabled, back to top don't appear before user scrolled the page.
3. Fix for external links alignment with mobile style.