### PR TITLE
fix: Break words on PC and Firefox

### DIFF
--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -18,6 +18,7 @@ pre, code { font-family: $code-font-family; }
 
 code {
   padding: 2px 4px;
+  overflow-wrap: break-word;
   word-wrap: break-word;
   color: $code-foreground;
   background: $code-background;
@@ -38,8 +39,8 @@ pre {
 
 .highlight {
   @extend $code-block;
-  // Read values from NexT config and set they as local variables to use as string variables (in any CSS section). 
-  hexo-config('codeblock.border_radius') is a 'unit' ? (cbradius = unit(hexo-config('codeblock.border_radius'), px)) : (cbradius = 1px) 
+  // Read values from NexT config and set they as local variables to use as string variables (in any CSS section).
+  hexo-config('codeblock.border_radius') is a 'unit' ? (cbradius = unit(hexo-config('codeblock.border_radius'), px)) : (cbradius = 1px)
   border-radius: cbradius;
 
   pre {

--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -17,9 +17,8 @@ $code-block {
 pre, code { font-family: $code-font-family; }
 
 code {
+  word-wrap();
   padding: 2px 4px;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
   color: $code-foreground;
   background: $code-background;
   border-radius: $code-border-radius;

--- a/source/css/_common/components/post/post-title.styl
+++ b/source/css/_common/components/post/post-title.styl
@@ -1,6 +1,6 @@
 .posts-expand .post-title {
   text-align: center;
-  word-break: break-word;
+  word-wrap: break-word;
   font-weight: $posts-expand-title-font-weight;
 
   if hexo-config('post_edit.enable') {

--- a/source/css/_common/components/post/post-title.styl
+++ b/source/css/_common/components/post/post-title.styl
@@ -1,7 +1,6 @@
 .posts-expand .post-title {
+  word-wrap();
   text-align: center;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
   font-weight: $posts-expand-title-font-weight;
 
   if hexo-config('post_edit.enable') {

--- a/source/css/_common/components/post/post-title.styl
+++ b/source/css/_common/components/post/post-title.styl
@@ -1,5 +1,6 @@
 .posts-expand .post-title {
   text-align: center;
+  overflow-wrap: break-word;
   word-wrap: break-word;
   font-weight: $posts-expand-title-font-weight;
 

--- a/source/css/_common/components/post/post.styl
+++ b/source/css/_common/components/post/post.styl
@@ -1,5 +1,6 @@
 .post-body {
   font-family: $font-family-posts;
+  overflow-wrap: break-word;
   word-wrap: break-word;
 }
 

--- a/source/css/_common/components/post/post.styl
+++ b/source/css/_common/components/post/post.styl
@@ -1,7 +1,6 @@
 .post-body {
+  word-wrap();
   font-family: $font-family-posts;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
 }
 
 .post-body span.exturl {

--- a/source/css/_common/components/post/post.styl
+++ b/source/css/_common/components/post/post.styl
@@ -1,8 +1,6 @@
 .post-body {
   font-family: $font-family-posts;
-  +mobile() {
-    word-break: break-word;
-  }
+  word-wrap: break-word;
 }
 
 .post-body span.exturl {

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -42,14 +42,13 @@ for headline in (1..6) {
 p { margin: 0 0 20px 0; }
 
 a, span.exturl {
+  word-wrap();
   // Remove the gray background color from active links in IE 10.
   background-color: transparent;
   color: $link-color;
   text-decoration: none;
   outline: none;
   border-bottom: 1px solid $link-decoration-color;
-  overflow-wrap: break-word;
-  word-wrap: break-word;
 
   &:hover,
   // Improve readability when focused.

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -48,6 +48,7 @@ a, span.exturl {
   text-decoration: none;
   outline: none;
   border-bottom: 1px solid $link-decoration-color;
+  overflow-wrap: break-word;
   word-wrap: break-word;
 
   &:hover,

--- a/source/css/_common/scaffolding/tables.styl
+++ b/source/css/_common/scaffolding/tables.styl
@@ -5,7 +5,7 @@ table {
   border-spacing: 0;
   border: 1px solid $table-border-color;
   font-size: $table-font-size;
-  word-wrap: break-all;
+  word-break: break-all;
 }
 table>tbody>tr {
   &:nth-of-type(odd) { background-color: $table-row-odd-bg-color; }

--- a/source/css/_mixins/base.styl
+++ b/source/css/_mixins/base.styl
@@ -102,3 +102,8 @@ clearfix() {
   }
   &:after { clear: both; }
 }
+
+word-wrap() {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number(s): fix #425 
1. break words doesn't work in PC.
2. Firefox doesn't support `word-break: break-word;`
https://caniuse.com/#search=word-break

## What is the new behavior?
Description about this pull, in several words...

* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1.	Short description of modified file [1].			xxxxxxx
2.	Short description of modified file [2].			xxxxxxx
3.	Short description of modified file [3].			xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
