### PR TITLE
Feat: Add display_in_post option for photos

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -283,6 +283,10 @@ post_meta:
     another_day: true
   categories: true
 
+# Post photo preview settings. Set photos in post front-matter first
+photos:
+  display_in_post: true
+
 # Post wordcount display settings
 # Dependencies: https://github.com/theme-next/hexo-symbols-count-time
 symbols_count_time:

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -283,7 +283,7 @@
     <div class="post-body{% if theme.han %} han-init-context{% endif %}{% if post.direction && post.direction.toLowerCase() === 'rtl' %} rtl{% endif %}" itemprop="articleBody">
 
       {# Gallery support #}
-      {% if post.photos and post.photos.length %}
+      {% if post.photos and post.photos.length and (theme.photos.display_in_post or is_index) %}
         <div class="post-gallery" itemscope itemtype="http://schema.org/ImageGallery">
           {% set COLUMN_NUMBER = 3 %}
           {% for photo in post.photos %}


### PR DESCRIPTION

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?

In the current theme, `preview_photo` is **locked at the top** of post.

This commit frees the location of `preview_photo`.


## What is the new behavior?

* Screens with this changes: 


**preview page**

<img width="50%" src="https://user-images.githubusercontent.com/13825126/47266625-cd74c900-d56b-11e8-8174-2e628d285be9.png">

**post page**

<table border="1"><colgroup><col width="30%"><col width="70%"></colgroup><tbody><tr><td><img title="enable read_more_btn" src="https://user-images.githubusercontent.com/13825126/47266547-c9947700-d56a-11e8-9d3f-08021c245b99.png"></td><td><img title="disable read_more_btn" src="https://user-images.githubusercontent.com/13825126/47266538-96ea7e80-d56a-11e8-8a9b-cbafe5a0e5d1.png"></td></tr></tbody></table>


Obviously, the right one is more flexible.

* Link to demo site with this changes:  http://blog.eson.org/

### How to use?

In Post
```
---
title: abc
photos:
  - file_path.jpg
---

...
```

In NexT `_config.yml`:
```yml
# Post photo preview settings. Set photos in post front-matter first
photos:
  display_in_post: false
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
