### PR TITLE
Menu external url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -135,6 +135,7 @@ exturl: false
 # Key is the name of menu item. If translate for this menu will find in languages - this translate will be loaded; if not - Key name will be used. Key is case-senstive.
 # Value before `||` delimeter is the target link.
 # Value after `||` delimeter is the name of FontAwesome icon. If icon (with or without delimeter) is not specified, question icon will be loaded.
+# External url should start with http:// or https:// .
 menu:
   home: / || home
   #about: /about/ || user

--- a/layout/_macro/menu/menu-item.swig
+++ b/layout/_macro/menu/menu-item.swig
@@ -1,7 +1,10 @@
 {% macro render(name, value) %}
 {% import 'menu-badge.swig' as menu_badge %}
 
-  {% set itemURL = value.split('||')[0] | replace('//', '/', 'g') | trim %}
+  {% set itemURL = value.split('||')[0] | trim %}
+  {% if itemURL.indexOf("http://") != 0 && itemURL.indexOf("https://") != 0 %}
+    {% set itemURL = itemURL | replace('//', '/', 'g') %}
+  {% endif %}
   <li class="menu-item menu-item-{{ itemName | replace(' ', '-', 'g') }}{{ item_active(itemURL, 'menu-item-active') }}">
 
     {% set menuText = __('menu.' + name ) | replace('menu.', '') %}

--- a/layout/_macro/menu/menu-item.swig
+++ b/layout/_macro/menu/menu-item.swig
@@ -2,7 +2,7 @@
 {% import 'menu-badge.swig' as menu_badge %}
 
   {% set itemURL = value.split('||')[0] | trim %}
-  {% if itemURL.indexOf("http://") != 0 && itemURL.indexOf("https://") != 0 %}
+  {% if itemURL.indexOf('http') != 0 %}
     {% set itemURL = itemURL | replace('//', '/', 'g') %}
   {% endif %}
   <li class="menu-item menu-item-{{ itemName | replace(' ', '-', 'g') }}{{ item_active(itemURL, 'menu-item-active') }}">

--- a/layout/_partials/header/sub-menu.swig
+++ b/layout/_partials/header/sub-menu.swig
@@ -21,7 +21,11 @@
               {% if itemName == 'default' %}
                 {% set parentValue = subvalue.split('||')[0] | trim %}
               {% else %}
-                {% set respath = parentValue + subvalue %}
+                {% if subvalue.indexOf("http://") == 0 || subvalue.indexOf("https://") == 0 %}
+                  {% set respath = subvalue %}
+                {% else %}
+                  {% set respath = parentValue + subvalue %}
+                {% endif %}
                 {{ menu_item.render(subname, respath) }}
               {% endif %}
             {% else %}
@@ -63,7 +67,11 @@
                         {% if itemName == 'default' %}
                           {% set parentSubValue = subvalue2.split('||')[0] | trim %}
                         {% else %}
-                          {% set respath2 = parentValue + parentSubValue + subvalue2 %}
+                          {% if subvalue2.indexOf("http://") == 0 || subvalue2.indexOf("https://") == 0 %}
+                            {% set respath2 = subvalue2 %}
+                          {% else %}
+                            {% set respath2 = parentValue + parentSubValue + subvalue2 %}
+                          {% endif %}
                           {{ menu_item.render(subname2, respath2) }}
                         {% endif %}
                       {% endfor %}

--- a/layout/_partials/header/sub-menu.swig
+++ b/layout/_partials/header/sub-menu.swig
@@ -21,7 +21,7 @@
               {% if itemName == 'default' %}
                 {% set parentValue = subvalue.split('||')[0] | trim %}
               {% else %}
-                {% if subvalue.indexOf("http://") == 0 || subvalue.indexOf("https://") == 0 %}
+                {% if subvalue.indexOf('http') == 0 %}
                   {% set respath = subvalue %}
                 {% else %}
                   {% set respath = parentValue + subvalue %}
@@ -67,7 +67,7 @@
                         {% if itemName == 'default' %}
                           {% set parentSubValue = subvalue2.split('||')[0] | trim %}
                         {% else %}
-                          {% if subvalue2.indexOf("http://") == 0 || subvalue2.indexOf("https://") == 0 %}
+                          {% if subvalue2.indexOf('http') == 0 %}
                             {% set respath2 = subvalue2 %}
                           {% else %}
                             {% set respath2 = parentValue + parentSubValue + subvalue2 %}

--- a/source/css/_schemes/Pisces/_sub-menu.styl
+++ b/source/css/_schemes/Pisces/_sub-menu.styl
@@ -8,12 +8,12 @@
 .sub-menu .menu-item {
   display: inline-block !important;
 
-  & a {
+  & a, span {
     padding: initial !important;
     margin: 5px 10px;
   }
 
-  & a:hover {
+  & a:hover, span:hover {
     background: initial !important;
     color: $sidebar-highlight;
   }

--- a/source/css/_schemes/Pisces/_sub-menu.styl
+++ b/source/css/_schemes/Pisces/_sub-menu.styl
@@ -8,12 +8,12 @@
 .sub-menu .menu-item {
   display: inline-block !important;
 
-  & a, span {
+  & a, span.exturl {
     padding: initial !important;
     margin: 5px 10px;
   }
 
-  & a:hover, span:hover {
+  & a:hover, span.exturl:hover {
     background: initial !important;
     color: $sidebar-highlight;
   }


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Menu didn't support jump to external links

Issue Number(s): N/A

## What is the new behavior?
Menu support jump to external links
![image](https://user-images.githubusercontent.com/15902347/48391631-6ac5b600-e742-11e8-94ab-4de848b9de87.png)
click google  jump to www.google.com

Config in the end of [this file](https://gitlab.com/JiangTJ/next-test/blob/master/_config.yml) 
Previews:
- Muse <https://jiangtj.gitlab.io/next-test/muse>
- Mist <https://jiangtj.gitlab.io/next-test/mist>
- Pisces <https://jiangtj.gitlab.io/next-test/pisces>
- Gemini <https://jiangtj.gitlab.io/next-test/gemini>

### How to use?
In NexT `_config.yml`:
```yml
  menu:
    home: / || home
    archives: /archives/ || archive
    google: https://www.google.com || google
    more:
      default: /more/ || info
      google: http://www.google.com || google
      more:
        google: https://www.google.com || google
        default: /more/ || info
```
**Note**
`default` is not supported, due to `default` is used for displaying some submenu info.


## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.