### PR TITLE
Define "builtin-name" for Lisp languages

### DIFF
--- a/source/css/_common/components/highlight/highlight.styl
+++ b/source/css/_common/components/highlight/highlight.styl
@@ -137,6 +137,7 @@ pre {
   .number
   .preprocessor
   .built_in
+  .builtin-name
   .literal
   .params
   .constant


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes have been added (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?

Lisp languages (like Scheme) don't highlight well.

![image1](https://user-images.githubusercontent.com/4580163/49494976-75d0b980-f89c-11e8-93e3-4eac065bb2ba.png)

## What is the new behavior?

Lisp languages should look better. Their builtin names will display in orange color, just as highlight.js does.

![image2](https://user-images.githubusercontent.com/4580163/49494987-7d905e00-f89c-11e8-8efa-913b097afba3.png)

### How to use?

❌

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

## More details

See https://github.com/highlightjs/highlight.js/commit/8616294df138a2895cd71fcb9a1483a1ce00b143