### PR TITLE
fix submenu when path name is same

### DIFF
--- a/layout/_partials/breadcrumb.swig
+++ b/layout/_partials/breadcrumb.swig
@@ -10,12 +10,12 @@
         {% if current == count - 1 %}
           <li>{{ path | upper }}</li>
         {% else %}
-          <li><a href="{{ link }}{{ url_for(path) }}/">{{ path | upper }}</a></li>
           {% if link == '' %}
             {% set link = '/' + path %}
           {% else %}
             {% set link += '/' + path %}
           {% endif %}
+          <li><a href="{{ url_for(link) }}/">{{ path | upper }}</a></li>
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/layout/_partials/header/sub-menu.swig
+++ b/layout/_partials/header/sub-menu.swig
@@ -52,8 +52,8 @@
 
                   {# If current URL is value of parent submenu 'default' path #}
                   {% set paths = page.path.split('/') %}
-                  {% for currentSubParentUrl in paths %}
-                    {% if currentSubParentUrl == subvalue.default.split('||')[0] | trim | replace('/', '', 'g') %}
+                  {% if paths.length > 2 %}
+                    {% if paths[1] == subvalue.default.split('||')[0] | trim | replace('/', '', 'g') %}
 
                       {# Submenu-2 items #}
                       <ul id="sub-menu-2" class="sub-menu menu">
@@ -71,7 +71,7 @@
                       {# End Submenu-2 items #}
 
                     {% endif %}
-                  {% endfor %}
+                  {% endif %}
                   {# End URL & path comparing #}
 
                 {% endif %}


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
When submenu path name is same, submenu2 is rendered twice
![image](https://user-images.githubusercontent.com/15902347/49728200-16641680-fcad-11e8-88a3-278c2ab06044.png)
![image](https://user-images.githubusercontent.com/15902347/49728171-08ae9100-fcad-11e8-857f-bdbe42f18663.png)

Issue Number(s): N/A

## What is the new behavior?

![image](https://user-images.githubusercontent.com/15902347/49728287-490e0f00-fcad-11e8-9cb0-aa3b60914e88.png)
![image](https://user-images.githubusercontent.com/15902347/49728307-54f9d100-fcad-11e8-84d0-9dcae7e4ba92.png)

* Screens with this changes: N/A
* Link to demo site with this changes: N/A


## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
