### PR TITLE
Fixed Disqus bug if in permalink exists symbol «'» .

### DIFF
--- a/layout/_third-party/comments/disqus.swig
+++ b/layout/_third-party/comments/disqus.swig
@@ -7,8 +7,8 @@
   {% if page.comments %}
     <script>
       var disqus_config = function () {
-        this.page.url = '{{ page.permalink }}';
-        this.page.identifier = '{{ page.path }}';
+        this.page.url = "{{ page.permalink }}";
+        this.page.identifier = "{{ page.path }}";
         this.page.title = '{{ page.title| addslashes }}';
         {% if __('disqus') !== 'disqus' -%}
           this.language = '{{ __('disqus') }}';


### PR DESCRIPTION
Issue number: #494

Before:
![image](https://user-images.githubusercontent.com/16944225/49870370-72e14600-fe13-11e8-8704-0a0201e55256.png)

After:
![image](https://user-images.githubusercontent.com/16944225/49870412-8f7d7e00-fe13-11e8-9065-391f1ad49971.png)