### PR TITLE
Fix inline code font-size mismatch within headers

### DIFF
--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -30,7 +30,6 @@ h1, h2, h3, h4, h5, h6 { margin: 20px 0 15px; }
 for headline in (1..6) {
   h{headline} {
     font-size: $font-size-headings-base - $font-size-headings-step * headline;
-
     code {
       font-size: $font-size-headings-base - $font-size-headings-step * headline;
     }
@@ -39,7 +38,6 @@ for headline in (1..6) {
   +mobile() {
     h{headline} {
       font-size: $font-size-headings-base - $font-size-headings-step * headline - 4px;
-
       code {
         font-size: $font-size-headings-base - $font-size-headings-step * headline - 4px;
       }

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -30,11 +30,19 @@ h1, h2, h3, h4, h5, h6 { margin: 20px 0 15px; }
 for headline in (1..6) {
   h{headline} {
     font-size: $font-size-headings-base - $font-size-headings-step * headline;
+
+    code {
+      font-size: $font-size-headings-base - $font-size-headings-step * headline;
+    }
   }
 
   +mobile() {
     h{headline} {
       font-size: $font-size-headings-base - $font-size-headings-step * headline - 4px;
+
+      code {
+        font-size: $font-size-headings-base - $font-size-headings-step * headline - 4px;
+      }
     }
   }
 }

--- a/source/css/_schemes/Gemini/index.styl
+++ b/source/css/_schemes/Gemini/index.styl
@@ -143,13 +143,22 @@ use_seo = hexo-config('seo');
   h1 {
     font-size: 1.6em;
     border-bottom: 1px solid $body-bg-color;
+    code {
+      font-size: 1em;
+    }
   }
   h2 {
     font-size: 1.45em;
     border-bottom: 1px solid $body-bg-color;
+    code {
+      font-size: 1em;
+    }
   }
   h3 {
     font-size: 1.3em;
+    code {
+      font-size: 1em;
+    }
     if use_seo {
       border-bottom: 1px solid $body-bg-color;
     } else {
@@ -158,15 +167,24 @@ use_seo = hexo-config('seo');
   }
   h4 {
     font-size: 1.2em;
+    code {
+      font-size: 1em;
+    }
     if use_seo {
       border-bottom: 1px dotted $body-bg-color;
     }
   }
   h5 {
     font-size: 1.07em;
+    code {
+      font-size: 1em;
+    }
   }
   h6 {
     font-size: 1.03em;
+    code {
+      font-size: 1em;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Any inline code within headers will have mismatched font-size. The inline code will have the same font-size as fenced code, whereas it should have adjusted to whatever font-size the header has.
![image](https://user-images.githubusercontent.com/3913002/50051241-76f3b900-00dc-11e9-9675-6ae9320a32bb.png)

Issue Number(s): N/A

## What is the new behavior?
The inline code should have adjusted to whatever font-size the header has.
![image](https://user-images.githubusercontent.com/3913002/50051300-74459380-00dd-11e9-8c76-e4fa2a94f1d7.png)

* Screens with this changes: above
* Link to demo site with this changes: https://bolunzhang.me/2018/12/14/static-versus-dynamic-libraries/

### How to use?
N/A

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
