### PR TITLE
Add toc max_depth support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -222,12 +222,12 @@ avatar:
 # Table Of Contents in the Sidebar
 toc:
   enable: true
-
   # Automatically add list number to toc.
   number: true
-
   # If true, all words will placed on next lines if header width longer then sidebar width.
   wrap: false
+  # Maximum heading depth of generated toc. You can set it in one post through `toc_max_depth` var.
+  max_depth: 6
 
 sidebar:
   # Sidebar Position, available value: left | right (only for Pisces | Gemini).

--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -157,11 +157,12 @@
         <div class="post-toc-wrap motion-element sidebar-panel sidebar-panel-active">
           <div class="post-toc">
 
-            {% if page.toc_number === undefined %}
-              {% set toc = toc(page.content, { "class": "nav", list_number: theme.toc.number }) %}
-            {% else %}
-              {% set toc = toc(page.content, { "class": "nav", list_number: page.toc_number }) %}
+            {% set next_toc_number = theme.toc.number %}
+            {% if page.toc_number !== undefined %}
+              {% set next_toc_number = page.toc_number %}
             {% endif %}
+            {% set next_toc_max_depth = page.toc_max_depth|default(theme.toc.max_depth)|default(6) %}
+            {% set toc = toc(page.content, { "class": "nav", list_number: next_toc_number, max_depth: next_toc_max_depth }) %}
 
             {% if toc.length <= 1 %}
               <p class="post-toc-empty">{{ __('post.toc_empty') }}</p>


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes have been added (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs have been added / updated (for bug fixes / features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Don't support set toc max_depth

Issue Number(s):  #527

## What is the new behavior?
Add toc max_depth support

* <https://jiangtj.gitlab.io/next-test/muse/2018/12/22/max_depth_in_config/>
* Config set max_depth: 2
* <https://jiangtj.gitlab.io/next-test/muse/2018/12/22/max_depth_in_post/>
* This post set toc_max_depth:1

### How to use?
In NexT `_config.yml`:
```yml
toc:
  # Maximum heading depth of generated toc. You can set it in one post through `toc_max_depth` var.
  max_depth: 6
```
Or in post:
```
toc_max_depth: 6
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
