### PR TITLE
Feat: Add quicklink support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -506,6 +506,11 @@ han: false
 # For more information: https://github.com/vinta/pangu.js
 pangu: false
 
+# quicklink Support
+# Dependencies: https://cdn.jsdelivr.net/npm/quicklink/dist/
+# Visit https://github.com/GoogleChromeLabs/quicklink for details
+quicklink: false
+
 # Swiftype Search API Key
 #swiftype_key:
 
@@ -1008,6 +1013,12 @@ vendors:
   # pangu: //cdn.jsdelivr.net/npm/pangu@3/dist/browser/pangu.min.js
   # pangu: //cdnjs.cloudflare.com/ajax/libs/pangu/3.3.0/pangu.min.js
   pangu:
+
+  # Internal version: 1.0.0
+  # See: https://github.com/GoogleChromeLabs/quicklink
+  # Example:
+  # quicklink: //cdn.jsdelivr.net/npm/quicklink@1.0.0/dist/quicklink.umd.js
+  quicklink:
 
   # Internal version: 1.0.0
   # See: https://github.com/revir/need-more-share2

--- a/layout/_layout.swig
+++ b/layout/_layout.swig
@@ -103,7 +103,7 @@
   {% block script_extra %}{% endblock %}
 
   {% include '_scripts/boostrap.swig' %}
-
+  {% include '_third-party/quicklink.swig' %}
   {% include '_third-party/comments/index.swig' %}
   {% include '_third-party/search/index.swig' %}
   {% include '_third-party/analytics/lean-analytics.swig' %}

--- a/layout/_third-party/quicklink.swig
+++ b/layout/_third-party/quicklink.swig
@@ -1,0 +1,17 @@
+{% if theme.quicklink %}
+  {% set quicklink_uri = url_for(theme.vendors._internal + '/quicklink/dist/quicklink.umd.js') %}
+  {% if theme.vendors.quicklink %}
+    {% set quicklink_uri = theme.vendors.quicklink %}
+  {% endif %}
+  <script src="{{ quicklink_uri }}"></script>
+  <script>
+		window.addEventListener('load', () => {
+      quicklink({
+        priority: true,
+        ignores: [
+          uri => uri.includes('#')
+        ]
+      });
+    });
+  </script>
+{% endif %}


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved N/A

## What is the new behavior?
When a page has finished loading, quicklink will attempt to use fetch() or falls back to XHR to prefetch URLs (same origin and ignore # such as #more) for links that are in-viewport during idle time.

Put simply, the links you can see will be prefetched. For example, if your sidebar is hidden at first, you need to open the sidebar to prefetch the rss link because you can't see it.

* Screens with this changes: 

![demo.gif](https://i.loli.net/2019/02/20/5c6d55d3e38fb.gif)

* [1v9's Blog](https://1v9.im)

### How to use?
In NexT `_config.yml`:
```yml
...
quicklink: true
...
vendors:
...
  quicklink: //cdn.jsdelivr.net/npm/quicklink@1.0.0/dist/quicklink.umd.js
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1. Short description of modified file [1].  xxxxxxx
2. Short description of modified file [2].  xxxxxxx
3. Short description of modified file [3].  xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
