### PR TITLE
Refactor: Add some options for quicklink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -507,10 +507,20 @@ han: false
 # For more information: https://github.com/vinta/pangu.js
 pangu: false
 
-# quicklink Support
+# Quicklink Support
 # Dependencies: https://cdn.jsdelivr.net/npm/quicklink/dist/
 # Visit https://github.com/GoogleChromeLabs/quicklink for details
-quicklink: false
+quicklink:
+  enable: false
+  timeout: 3000 # Custom a timeout (milliseconds) for prefetching resources
+  priority: true # Set true to enable fetch() or falls back to XHR
+  # For more flexibility you can add some patterns (RegExp, Function, or Array) to ignores
+  # See: https://github.com/GoogleChromeLabs/quicklink#custom-ignore-patterns
+  # Leave ignores as empty if you don't understand what it means
+  # Example:
+  # ignores: uri => uri.includes('.xml'), (uri, elem) => elem.hasAttribute('noprefetch')
+  # ignores: [/\/api\/?/, uri => uri.includes('123.html')]
+  ignores:
 
 # Swiftype Search API Key
 #swiftype_key:

--- a/layout/_third-party/quicklink.swig
+++ b/layout/_third-party/quicklink.swig
@@ -1,4 +1,4 @@
-{% if theme.quicklink %}
+{% if theme.quicklink and theme.quicklink.enable %}
   {% set quicklink_uri = url_for(theme.vendors._internal + '/quicklink/dist/quicklink.umd.js') %}
   {% if theme.vendors.quicklink %}
     {% set quicklink_uri = theme.vendors.quicklink %}
@@ -7,10 +7,9 @@
   <script>
 		window.addEventListener('load', () => {
       quicklink({
-        priority: true,
-        ignores: [
-          uri => uri.includes('#')
-        ]
+        timeout: {{ theme.quicklink.timeout }},
+        priority: {{ theme.quicklink.priority }},
+        ignores: [uri => uri.includes('#'), {{ theme.quicklink.ignores }}]
       });
     });
   </script>


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved N/A

## What is the new behavior?
Remove hardcode in quicklink.swig, now timeout, priority, ignores can be set up in _config.yml,

* Screens with this changes:

> My server is in Seattle, it seems too bad, please ignore the network delay, which has nothing to do with quicklink.

![](https://i.loli.net/2019/02/24/5c72395697749.gif)

* [1v9's Blog](https://1v9.im)

### How to use?
In NexT `_config.yml`:
```yml
...
quicklink:
  enable: true
  timeout: 3000
  priority: true
  ignores:
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.