### PR TITLE
Feat: Add another copy button variant

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -316,6 +316,8 @@ codeblock:
     enable: false
     # Show text copy result
     show_result: false
+    # Style: only 'flat' is currently available, leave it blank if you prefer default theme
+    style:
 
 # Wechat Subscriber
 wechat_subscriber:
@@ -633,7 +635,7 @@ needmoreshare2:
 #google_site_verification:
 
 # Google Analytics
-# google_analytics: 
+# google_analytics:
 #   tracking_id:
 #   localhost_ignored: true
 

--- a/layout/_third-party/copy-code.swig
+++ b/layout/_third-party/copy-code.swig
@@ -10,10 +10,15 @@
       white-space: nowrap;
       vertical-align: middle;
       cursor: pointer;
-      background-color: #eee;
-      background-image: linear-gradient(#fcfcfc, #eee);
-      border: 1px solid #d5d5d5;
-      border-radius: 3px;
+      {% if theme.codeblock.copy_button.style === 'flat' %}
+        background-color: #fff;
+        border: none;
+      {% else %}
+        background-color: #eee;
+        background-image: linear-gradient(#fcfcfc, #eee);
+        border: 1px solid #d5d5d5;
+        border-radius: 3px;
+      {% endif %}
       user-select: none;
       outline: 0;
     }
@@ -23,13 +28,18 @@
       opacity: 0;
       padding: 2px 6px;
       position: absolute;
-      right: 4px;
-      top: 8px;
+      {% if theme.codeblock.copy_button.style === 'flat' %}
+        right: 0px;
+        height: 42px;
+      {% else %}
+        right: 4px;
+        top: 8px;
+      {% endif %}
     }
 
     .highlight-wrap:hover .copy-btn,
     .highlight-wrap .copy-btn:focus {
-      opacity: 1
+      opacity: 1;
     }
 
     .highlight-wrap {


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Only one style available for copy button.

Issue resolved N/A

## What is the new behavior?
Will be able to use another style of button: `flat`
Multi-line:
![image](https://user-images.githubusercontent.com/9370547/53411995-113c7b00-3a03-11e9-9c13-d49c2ccfbbbc.png)
Single-line:
![image](https://user-images.githubusercontent.com/9370547/53412003-17caf280-3a03-11e9-8386-227558569b1e.png)


* Screens with this changes: N/A
* Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
codeblock:
  # Manual define the border radius in codeblock
  # Leave it empty for the default 1
  border_radius:
  # Add copy button on codeblock
  copy_button:
    enable: true
    # Show text copy result
    show_result: true
    # Style: only 'flat' is currently available, leave it blank if you prefer default theme
    style: flat
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.