### PR TITLE
Refactor: copy code

### DIFF
--- a/layout/_third-party/copy-code.swig
+++ b/layout/_third-party/copy-code.swig
@@ -55,27 +55,22 @@
           return $(e).text();
         }).toArray().join('\n');
         var ta = document.createElement('textarea');
-        var range = document.createRange(); //For Chrome
-        var sel = window.getSelection(); //For Chrome
         var yPosition = window.pageYOffset || document.documentElement.scrollTop;
-        ta.style.top = yPosition + 'px'; //Prevent page scroll
+        ta.style.top = yPosition + 'px'; // Prevent page scroll
         ta.style.position = 'absolute';
         ta.style.opacity = '0';
+        ta.readOnly = true;
         ta.value = code;
-        ta.textContent = code; //For FireFox
-        ta.contentEditable = true;
-        ta.readOnly = false;
         document.body.appendChild(ta);
-        range.selectNode(ta);
-        sel.removeAllRanges();
-        sel.addRange(range);
+        ta.select();
         ta.setSelectionRange(0, code.length);
+        ta.readOnly = false;
         var result = document.execCommand('copy');
         {% if theme.codeblock.copy_button.show_result %}
           if (result) $(this).text('{{__("post.copy_success")}}');
           else $(this).text('{{__("post.copy_failure")}}');
         {% endif %}
-        ta.blur(); //For iOS
+        ta.blur(); // For iOS
         $(this).blur();
       })).on('mouseleave', function(e) {
         var $b = $(this).find('.copy-btn');


### PR DESCRIPTION
Refactor it with how clipboard.js works under the hood

<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you copy something like this:
![image](https://user-images.githubusercontent.com/9370547/53421560-d34a5180-3a18-11e9-90d6-59dc4cdfb368.png)
In chromium-based browsers, it will result in: (There's a linefeed on the start.)
![image](https://user-images.githubusercontent.com/9370547/53421590-dc3b2300-3a18-11e9-9f94-d2d30df4378b.png)

Issue resolved N/A

## What is the new behavior?
The linefeed on the start will no longer exist, and it compatibility should be as good as https://clipboardjs.com/#browser-support

* Screens with this changes: N/A
* Link to demo site with this changes: https://blog.maple3142.net/

### How to use?
No

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.