### PR TITLE
Refactor: Improve usage of quicklink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -514,10 +514,11 @@ pangu: false
 quicklink:
   enable: false
 
-  # Default (true) will load quicklink.umd.js script on demand.
-  # That is it only render those page which has `quicklink: true` in Front Matter.
-  # If you set it to false, it will load quicklink.umd.js srcipt EVERY PAGE.
-  per_page: true
+  # Quicklink (quicklink.umd.js script) is loaded on demand
+  # Add `quicklink: true` in Front Matter of the page or post you need
+  # Home page and archive page can be controlled through home and archive options below
+  home: true
+  archive: true
 
   # Default (true) will initialize quicklink after the load event fires
   delay: true

--- a/layout/_third-party/quicklink/index.swig
+++ b/layout/_third-party/quicklink/index.swig
@@ -1,20 +1,22 @@
 {% if theme.quicklink.enable %}
-  {% set is_index_has_quicklink = false %}
-
-  {# At home, check if there has `quicklink: true` post #}
-  {% if is_home() %}
-    {% for post in page.posts %}
-      {% if post.quicklink and not is_index_has_quicklink %}
-        {% set is_index_has_quicklink = true %}
-      {% endif %}
-    {% endfor %}
+  {% set quicklink_uri = url_for(theme.vendors._internal + '/quicklink/dist/quicklink.umd.js') %}
+  {% if theme.vendors.quicklink %}
+    {% set quicklink_uri = theme.vendors.quicklink %}
   {% endif %}
 
-  {% if not theme.quicklink.per_page or (is_index_has_quicklink or page.quicklink) %}
-    {% set quicklink_uri = url_for(theme.vendors._internal + '/quicklink/dist/quicklink.umd.js') %}
-    {% if theme.vendors.quicklink %}
-      {% set quicklink_uri = theme.vendors.quicklink %}
+  {% if is_home() %}
+    {% if theme.quicklink.home %}
+      {% set loadQL = true %}
     {% endif %}
+  {% endif %}
+
+  {% if is_archive() %}
+    {% if theme.quicklink.archive %}
+      {% set loadQL = true %}
+    {% endif %}
+  {% endif %}
+  
+  {% if loadQL or (page.quicklink or post.quicklink) %}
     <script src="{{ quicklink_uri }}"></script>
     <script>
       {% if theme.quicklink.delay %}


### PR DESCRIPTION
<!-- ATTENTION!

1. Please, write pulls readme in English. Not all contributors/collaborators know Chinese language and Google translate can't always give true translates on issues. Thanks!

2. If your pull is short and simple, recommended to use "Usual pull template".
   If your pull is big and include many separated changes, recommended to use "BIG pull template".

3. Always remember what NexT include 4 schemes. And if on one of them all worked fine after changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

<!-- Usual pull template -->

## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**  <!-- (Check one with "x") -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
#637 introduced `per_page: true` option to load quicklink on demand, but home page and archive page can't be fully controlled.

## What is the new behavior?
* Now quicklink will load on demand by default.
* add `quicklink: true` in front matter for those pages or posts you want.
* Home page and archive page can be controlled through `home: ` and `archive: ` option.
 

### How to use?
In NexT `_config.yml`:
```diff
quicklink:
  enable: true 
- per_page: true
+ home: true # enable or disable quicklink on home page
+ archive: true # enable or disable quicklink on archive page
# Add `quicklink: true` in front matter to enable quicklink on special page or post
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- BIG pull template -->
<!--
1. xxxxxxx - commit link on modified file. Just copy this below your pull request readme.
2. You can paste any image directly from your clipboard. Just press **Print Scr** and paste it into pull readme - link on image will generate and paste automaticly.
-->
<!--
## PART X. Title of fixes and/or enhancements.
Short description in several words here.

Issue Number(s): #xxxx.

### Files modified:
1. Short description of modified file [1].  xxxxxxx
2. Short description of modified file [2].  xxxxxxx
3. Short description of modified file [3].  xxxxxxx

### Global code changes:
* ADD: `newFunction` in `utils.js`.
* DEL: `oldFunction` from `utils.js`

### How it looks?
![image](https://user-images.githubusercontent.com/xxxxxxxx/xxxxxxxx-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx.png)

Live demo [here](http://site.com/).

### How to use?
In Next `_config.yml`:
```yml
...
```
-->
