### PR TITLE
Feat: Add force language to Gitalk

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -617,11 +617,15 @@ gitment:
 gitalk:
   enable: false
   github_id:  # Github repo owner
-  repo:  # Repository name to store issues.
+  repo:  # Repository name to store issues
   client_id:  # Github Application Client ID
   client_secret:  # Github Application Client Secret
   admin_user:  # GitHub repo owner and collaborators, only these guys can initialize github issues
   distraction_free_mode: true # Facebook-like distraction free mode
+  # Gitalk's display language depends on user's browser or system environment
+  # If you want everyone visiting your site to see a uniform language, you can set a force language value
+  # Available value: en, es-ES, fr, ru, zh-CN, zh-TW
+  language:
 
 # Baidu Share
 # Available values: button | slide

--- a/layout/_third-party/comments/gitalk.swig
+++ b/layout/_third-party/comments/gitalk.swig
@@ -24,6 +24,11 @@
     owner: '{{ theme.gitalk.github_id }}',
     admin: ['{{ theme.gitalk.admin_user }}'],
     id: md5(location.pathname),
+    {% if theme.gitalk.language == '' %}
+      language: window.navigator.language || window.navigator.userLanguage,
+    {% else %}
+      language: '{{ theme.gitalk.language }}',
+    {% endif %}
     distractionFreeMode: '{{ theme.gitalk.distraction_free_mode }}'
   });
   gitalk.render('gitalk-container');


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Issue resolved: #651

## What is the new behavior?
* Language can be foced.
* leave language empty, same as before
![zh-CN.jpg](https://i.loli.net/2019/03/04/5c7d287b91b20.jpg)
* Add es-ES
![es-ES.jpg](https://i.loli.net/2019/03/04/5c7d2895da345.jpg)

### How to use?
In NexT `_config.yml`:
```yml
gitalk:
  enable: false
  github_id:  # Github repo owner
  repo:  # Repository name to store issues
  client_id:  # Github Application Client ID
  client_secret:  # Github Application Client Secret
  admin_user:  # GitHub repo owner and collaborators, only these guys can initialize github issues
  distraction_free_mode: true # Facebook-like distraction free mode
  # Gitalk's display language depends on user's browser or system environment
  # If you want everyone visiting your site to see a uniform language, you can set a force language value
  # Available value: en, es-ES, fr, ru, zh-CN, zh-TW
+ language:
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
