### PR TITLE
 fix diff code hightlight problem

### DIFF
--- a/source/css/_common/components/highlight/diff.styl
+++ b/source/css/_common/components/highlight/diff.styl
@@ -4,5 +4,5 @@ if $highlight_theme == "normal"
   $highlight-deletion     = #fdd
   $highlight-addition     = #dfd
 else
-  $highlight-deletion     = #008000
-  $highlight-addition     = #800000
+  $highlight-deletion     = #800000
+  $highlight-addition     = #008000


### PR DESCRIPTION
```diff
+ green background for added line
- red for deleted line
but old css style use wrong colors
```

<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
for diff code block, currently it make wrong background color for added/deleted line for some hight theme.

Issue resolved: yes

## What is the new behavior?
exchange the color variable value and problem sovled.

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
just a small change for css style

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.
