### PR TITLE
Fix lost tracking_id in google_analytics

### DIFF
--- a/layout/_third-party/analytics/google-analytics.swig
+++ b/layout/_third-party/analytics/google-analytics.swig
@@ -1,5 +1,5 @@
 {% if theme.google_analytics.tracking_id %}
-  <script async src="//www.googletagmanager.com/gtag/js?id={{ theme.google_analytics }}"></script>
+  <script async src="//www.googletagmanager.com/gtag/js?id={{ theme.google_analytics.tracking_id }}"></script>
   <script>
     var host = window.location.hostname;
     if (host !== "localhost" || !{{theme.google_analytics.localhost_ignored}}) {


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
google tag will load like this `//www.googletagmanager.com/gtag/js?id=[object%20Object]`
Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words... -->
 `//www.googletagmanager.com/gtag/js?id=UA-XXXXXXX-XXX`
- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
Change `google-analytics.swig` from
``` swig
<script async src="//www.googletagmanager.com/gtag/js?id={{ theme.google_analytics }}"></script>
```
to
``` swig
<script async src="//www.googletagmanager.com/gtag/js?id={{ theme.google_analytics.tracking_id }}"></script>
```
## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
