### PR TITLE
Bugfix: `back2top` button on mobile, sidebar item margin and sidebar `exturl` link color

### DIFF
--- a/source/css/_common/components/back-to-top-sidebar.styl
+++ b/source/css/_common/components/back-to-top-sidebar.styl
@@ -9,7 +9,7 @@
   -webkit-transform: translateZ(0);
     &:hover { opacity: 0.8; }
 
-  +tablet()-mobile() {
+  +tablet-mobile() {
     hexo-config('sidebar.onmobile') ? fixbutton() : hide();
   }
 

--- a/source/css/_common/components/back-to-top-sidebar.styl
+++ b/source/css/_common/components/back-to-top-sidebar.styl
@@ -9,13 +9,8 @@
   -webkit-transform: translateZ(0);
     &:hover { opacity: 0.8; }
 
-  +tablet() {
-    fixbutton() if hexo-config('sidebar.onmobile');
-    hide() if not hexo-config('sidebar.onmobile');
-  }
-  +mobile() {
-    fixbutton() if hexo-config('sidebar.onmobile');
-    hide() if not hexo-config('sidebar.onmobile');
+  +tablet()-mobile() {
+    hexo-config('sidebar.onmobile') ? fixbutton() : hide();
   }
 
   &.back-to-top-on {

--- a/source/css/_common/components/back-to-top.styl
+++ b/source/css/_common/components/back-to-top.styl
@@ -16,15 +16,6 @@
   transition-property: bottom;
   the-transition();
 
-  +tablet() {
-    fixbutton() if hexo-config('sidebar.onmobile');
-    hide() if not hexo-config('sidebar.onmobile');
-  }
-  +mobile() {
-    fixbutton() if hexo-config('sidebar.onmobile');
-    hide() if not hexo-config('sidebar.onmobile');
-  }
-
   &.back-to-top-on {
     bottom: $b2t-position-bottom-on;
   }

--- a/source/css/_common/components/back-to-top.styl
+++ b/source/css/_common/components/back-to-top.styl
@@ -19,4 +19,7 @@
   &.back-to-top-on {
     bottom: $b2t-position-bottom-on;
   }
+  &:hover {
+    color: $sidebar-highlight;
+  }
 }

--- a/source/css/_common/components/post/post.styl
+++ b/source/css/_common/components/post/post.styl
@@ -3,7 +3,7 @@
   font-family: $font-family-posts;
 }
 
-.post-body .exturl {
+.post-body span.exturl {
   .fa {
     font-size: 14px;
     margin-left: 4px;

--- a/source/css/_common/components/sidebar/sidebar-author-links.styl
+++ b/source/css/_common/components/sidebar/sidebar-author-links.styl
@@ -1,25 +1,24 @@
 .links-of-author {
   margin-top: 20px;
-}
 
-.links-of-author a,
-.links-of-author .exturl {
-  display: inline-block;
-  vertical-align: middle;
-  margin-right: 10px;
-  margin-bottom: 10px;
-  border-bottom-color: $black-light;
-  font-size: 13px;
-  if hexo-config('social_icons.transition') { the-transition(); }
-
-  &:before {
+  a, span.exturl {
     display: inline-block;
     vertical-align: middle;
-    margin-right: 3px;
-    content: " ";
-    width: 4px;
-    height: 4px;
-    border-radius: 50%;
-    background: rgb(random-color(0, 255) - 50%, random-color(0, 255) - 50%, random-color(0, 255) - 50%);
+    margin-right: 10px;
+    margin-bottom: 10px;
+    border-bottom-color: $black-light;
+    font-size: 13px;
+    if hexo-config('social_icons.transition') { the-transition(); }
+
+    &:before {
+      display: inline-block;
+      vertical-align: middle;
+      margin-right: 3px;
+      content: " ";
+      width: 4px;
+      height: 4px;
+      border-radius: 50%;
+      background: rgb(random-color(0, 255) - 50%, random-color(0, 255) - 50%, random-color(0, 255) - 50%);
+    }
   }
 }

--- a/source/css/_common/components/sidebar/sidebar-blogroll.styl
+++ b/source/css/_common/components/sidebar/sidebar-blogroll.styl
@@ -1,7 +1,10 @@
-.links-of-blogroll { font-size: 13px; }
+.links-of-blogroll {
+  margin-top: 10px;
+  font-size: 13px;
+}
 
 .links-of-blogroll-title {
-  margin-top: 20px;
+  margin-top: 0;
   font-size: 14px;
   font-weight: $font-weight-bold;
 }

--- a/source/css/_common/components/sidebar/sidebar-toggle.styl
+++ b/source/css/_common/components/sidebar/sidebar-toggle.styl
@@ -1,4 +1,7 @@
 .sidebar-toggle {
+  &:hover .sidebar-toggle-line {
+    background: $sidebar-highlight;
+  }
   position: fixed;
   right: $b2t-position-right;
   bottom: 45px;

--- a/source/css/_common/components/sidebar/sidebar.styl
+++ b/source/css/_common/components/sidebar/sidebar.styl
@@ -10,12 +10,12 @@
   background: $black-deep;
   -webkit-transform: translateZ(0); // http://stackoverflow.com/questions/17079857/position-fixed-broken-in-chrome-with-flash-behind
 
-  a, .exturl {
+  a, span.exturl {
     color: $grey-dark;
     border-bottom-color: $black-light;
     &:hover { color: $gainsboro; }
   }
-  .exturl:hover {
+  span.exturl:hover {
     border-bottom-color: $gainsboro;
   }
 

--- a/source/css/_common/components/sidebar/sidebar.styl
+++ b/source/css/_common/components/sidebar/sidebar.styl
@@ -10,12 +10,6 @@
   background: $black-deep;
   -webkit-transform: translateZ(0); // http://stackoverflow.com/questions/17079857/position-fixed-broken-in-chrome-with-flash-behind
 
-  a, .exturl {
-    color: $grey-dark;
-    border-bottom-color: $black-light;
-    &:hover { color: $gainsboro; }
-  }
-
   +tablet() {
     hide() if not hexo-config('sidebar.onmobile');
   }

--- a/source/css/_common/components/sidebar/sidebar.styl
+++ b/source/css/_common/components/sidebar/sidebar.styl
@@ -10,6 +10,15 @@
   background: $black-deep;
   -webkit-transform: translateZ(0); // http://stackoverflow.com/questions/17079857/position-fixed-broken-in-chrome-with-flash-behind
 
+  a, .exturl {
+    color: $grey-dark;
+    border-bottom-color: $black-light;
+    &:hover { color: $gainsboro; }
+  }
+  .exturl:hover {
+    border-bottom-color: $gainsboro;
+  }
+
   +tablet() {
     hide() if not hexo-config('sidebar.onmobile');
   }

--- a/source/css/_mixins/Pisces.styl
+++ b/source/css/_mixins/Pisces.styl
@@ -2,7 +2,7 @@ sidebar-inline-links-item() {
   margin: 5px 0 0;
   if !hexo-config('social_icons.icons_only') { width: 50%; }
 
-  & a, .exturl {
+  & a, span.exturl {
     max-width: 216px;
     box-sizing: border-box;
     display: inline-block;

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -127,10 +127,8 @@
 
 .links-of-blogroll {
   text-align: center;
-  margin-top: 5px;
   padding: 3px 0 0;
 }
-.links-of-blogroll-title { margin-top: 0; }
 .links-of-blogroll-item { padding: 0; }
 .links-of-blogroll-inline {
   clearfix();

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -7,6 +7,13 @@
   // Do NOT delete this line
   // or Affix (position: fixed) will not work in Google Chrome.
   -webkit-transform: none;
+
+  a, span.exturl {
+    color: $black-light;
+
+    &:hover { color: $black-deep; }
+  }
+  .exturl:hover { border-bottom-color: $black-deep; }
 }
 
 .sidebar-inner {

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -38,13 +38,6 @@
   clearfix();
 }
 
-.sidebar a,
-.sidebar span.exturl {
-  color: $black-light;
-
-  &:hover { color: $black-deep; }
-}
-
 .site-state-item {
   padding: 0 10px;
 }

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -13,7 +13,7 @@
 
     &:hover { color: $black-deep; }
   }
-  .exturl:hover { border-bottom-color: $black-deep; }
+  span.exturl:hover { border-bottom-color: $black-deep; }
 }
 
 .sidebar-inner {

--- a/source/js/src/post-details.js
+++ b/source/js/src/post-details.js
@@ -89,7 +89,8 @@ $(document).ready(function() {
   var display = CONFIG.page.sidebar;
   if (typeof display !== 'boolean') {
     // There's no definition sidebar in the page front-matter
-    var isSidebarCouldDisplay = CONFIG.sidebar.display === 'post' || CONFIG.sidebar.display === 'always';
+    var isSidebarCouldDisplay = CONFIG.sidebar.display === 'post'
+     || CONFIG.sidebar.display === 'always';
     var hasTOC = $tocContent.length > 0 && $tocContent.html().trim().length > 0;
     display = isSidebarCouldDisplay && hasTOC;
   }

--- a/source/js/src/post-details.js
+++ b/source/js/src/post-details.js
@@ -89,8 +89,7 @@ $(document).ready(function() {
   var display = CONFIG.page.sidebar;
   if (typeof display !== 'boolean') {
     // There's no definition sidebar in the page front-matter
-    var isSidebarCouldDisplay = CONFIG.sidebar.display === 'post'
-     || CONFIG.sidebar.display === 'always';
+    var isSidebarCouldDisplay = CONFIG.sidebar.display === 'post' || CONFIG.sidebar.display === 'always';
     var hasTOC = $tocContent.length > 0 && $tocContent.html().trim().length > 0;
     display = isSidebarCouldDisplay && hasTOC;
   }


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [x] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![屏幕快照 2019-03-17 上午1 04 54](https://user-images.githubusercontent.com/16272760/54478780-dcc51d80-4850-11e9-9a48-ea38daf4ca17.png)

Issue resolved: #482

## What is the new behavior?
<!-- Description about this pull, in several words... -->

Fixed 3 bugs:
- #482, make back2top display on mobile 
- Add spaces between sidebar elements
- Add `border-bottom-color` settings of `exturl` in sidebar

- Screenshots with this changes: N/A

![屏幕快照 2019-03-17 上午1 05 00](https://user-images.githubusercontent.com/16272760/54478782-e2bafe80-4850-11e9-819f-229db58ea20b.png)

- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
