### PR TITLE
Fix #578: Link color in modern notes with `exturl`

### DIFF
--- a/source/css/_common/components/tags/note-modern.styl
+++ b/source/css/_common/components/tags/note-modern.styl
@@ -53,7 +53,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-default-text;
         border-bottom:   1px solid $note-modern-default-text;
@@ -76,7 +76,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-primary-text;
         border-bottom:   1px solid $note-modern-primary-text;
@@ -99,7 +99,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-info-text;
         border-bottom:   1px solid $note-modern-info-text;
@@ -122,7 +122,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-success-text;
         border-bottom:   1px solid $note-modern-success-text;
@@ -145,7 +145,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-warning-text;
         border-bottom:   1px solid $note-modern-warning-text;
@@ -168,7 +168,7 @@
         }
       }
     }
-    a {
+    a, span.exturl {
       &:not(.btn) {
         color:                     $note-modern-danger-text;
         border-bottom:   1px solid $note-modern-danger-text;

--- a/source/css/_common/components/tags/note.styl
+++ b/source/css/_common/components/tags/note.styl
@@ -1,6 +1,6 @@
 .post-body .note {
-  note_style = hexo-config('note.style');
   note_icons = hexo-config('note.icons');
+  note_style = hexo-config('note.style');
 
   position:             relative;
   padding:              15px;


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved: #578

## What is the new behavior?
<!-- Description about this pull, in several words... -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
