### PR TITLE
Make `site-state-item` centered using `flex`

### DIFF
--- a/source/css/_common/components/sidebar/site-state.styl
+++ b/source/css/_common/components/sidebar/site-state.styl
@@ -1,4 +1,6 @@
 .site-state {
+  display: flex;
+  justify-content: center;
   overflow: hidden;
   line-height: 1.4;
   white-space: nowrap;
@@ -7,7 +9,6 @@
 }
 
 .site-state-item {
-  display: inline-block;
   padding: 0 15px;
   border-left: 1px solid $site-state-item-border-color;
 


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved: N/A
![屏幕快照 2019-03-17 上午2 14 52](https://user-images.githubusercontent.com/16272760/54480265-346b8500-4861-11e9-8869-0346121b1baa.png)
![屏幕快照 2019-03-17 上午2 14 57](https://user-images.githubusercontent.com/16272760/54480266-35041b80-4861-11e9-92d2-fbc5f5f75aa6.png)

## What is the new behavior?
<!-- Description about this pull, in several words... -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A
![屏幕快照 2019-03-17 上午2 34 41](https://user-images.githubusercontent.com/16272760/54480270-3c2b2980-4861-11e9-83a2-5d2476f99730.png)


### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
