### PR TITLE
Reduce the scope of 'list-style-position: inside !important;' attribute

### DIFF
--- a/layout/_third-party/math/mathjax.swig
+++ b/layout/_third-party/math/mathjax.swig
@@ -33,7 +33,11 @@
   MathJax.Hub.Queue(function() {
     var all = MathJax.Hub.getAllJax(), i;
     for (i = 0; i < all.length; i += 1) {
-      document.getElementById(all[i].inputID + '-Frame').parentNode.className += ' has-jax';
+      parent = document.getElementById(all[i].inputID + '-Frame').parentNode;
+      parent.classList.add('has-jax');
+      if (parent.tagName.toLowerCase() === 'li') {
+        parent.parentNode.classList.add('has-jax-list');
+      }
     }
   });
 </script>

--- a/source/css/_common/components/third-party/math.styl
+++ b/source/css/_common/components/third-party/math.styl
@@ -3,6 +3,6 @@
   overflow-y: hidden;
 }
 
-li {
+.has-jax-list>li {
   list-style-position: inside !important;
 }


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
This is an amend PR for #669 which commit by me.
In that PR I add `list-style-position: inside !important;`  for `li` element, because `overflow` attribute will make the leading symbol (dot/circle for unordered or number for ordered) disappear.
However, with more test I found that, this phenomenon **only** take case if `li`  itself has `overflow` attribute, not when its child elements has overflow attribute.

Just try the following html code and you will understand what I mean [https://www.w3schools.com/Html/tryit.asp?filename=tryhtml_intro](https://www.w3schools.com/Html/tryit.asp?filename=tryhtml_intro)
```html
<!DOCTYPE html>
<html>
<body>
<style>
.has-jax {
	overflow-x: auto;
    overflow-y: hidden;
}
.change_position {
	list-style-position: inside !important;
}
</style>

<ul>
<li class='has-jax'>li with overflow, dot disappera</li>
<li class='has-jax'>li with overflow, dot disappera</li>
</ul>

<ul>
<li><p class='has-jax'>p inside li with overflow, every thing is ok</p></li>
<li><p class='has-jax'>p inside li with overflow, no need to fix</p></li>
</ul>


<ul>
<li class='has-jax change_position'>li with overflow, I fixed it</li>
<li class='has-jax change_position'>li with overflow, I fixed it</li>
</ul>
</body>
</html>
```

## What is the new behavior?
So, I reduce the effect scope of the css selector, this is safer.
In fact, `list-style-position: inside !important;` attribute has some side effect on some browser, it will make the leading symbol and list item content displayed in two different line. With this constraint, such side effect is eliminated.


## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.
