### PR TITLE
Improved canonical path for vision in Google.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -185,7 +185,7 @@ scheme: Muse
 
 # ---------------------------------------------------------------
 # Sidebar Settings
-# See: https://theme-next.org/docs/theme-settings/sidebar/
+# See: https://theme-next.org/docs/theme-settings/sidebar
 # ---------------------------------------------------------------
 
 # Posts / Categories / Tags in sidebar.
@@ -290,7 +290,7 @@ chat:
 
 # ---------------------------------------------------------------
 # Post Settings
-# See: https://theme-next.org/docs/theme-settings/posts/
+# See: https://theme-next.org/docs/theme-settings/posts
 # ---------------------------------------------------------------
 
 # Set the text alignment in the posts.
@@ -597,7 +597,7 @@ calendar:
 
 # ---------------------------------------------------------------
 # Comments and Widgets
-# See: https://theme-next.org/docs/third-party-services/comments-and-widgets/
+# See: https://theme-next.org/docs/third-party-services/comments-and-widgets
 # ---------------------------------------------------------------
 
 # Disqus
@@ -682,7 +682,7 @@ gitalk:
 
 # ---------------------------------------------------------------
 # Content Sharing Services
-# See: https://theme-next.org/docs/third-party-services/content-sharing-services/
+# See: https://theme-next.org/docs/third-party-services/content-sharing-services
 # ---------------------------------------------------------------
 
 # Baidu Share
@@ -741,7 +741,7 @@ needmoreshare2:
 
 # ---------------------------------------------------------------
 # Statistics and Analytics
-# See: https://theme-next.org/docs/third-party-services/statistics-and-analytics/
+# See: https://theme-next.org/docs/third-party-services/statistics-and-analytics
 # ---------------------------------------------------------------
 
 # Baidu Analytics ID
@@ -841,7 +841,7 @@ busuanzi_count:
 
 # ---------------------------------------------------------------
 # Search Services
-# See: https://theme-next.org/docs/third-party-services/search-services/
+# See: https://theme-next.org/docs/third-party-services/search-services
 # ---------------------------------------------------------------
 
 # Algolia Search
@@ -874,7 +874,7 @@ local_search:
 
 # ---------------------------------------------------------------
 # Chat Services
-# See: https://theme-next.org/docs/third-party-services/chat-services/
+# See: https://theme-next.org/docs/third-party-services/chat-services
 # ---------------------------------------------------------------
 
 # Chatra Support
@@ -1023,7 +1023,7 @@ canvas_ribbon:
 #! ---------------------------------------------------------------
 #! DO NOT EDIT THE FOLLOWING SETTINGS
 #! UNLESS YOU KNOW WHAT YOU ARE DOING
-#! See: https://theme-next.org/docs/advanced-settings/
+#! See: https://theme-next.org/docs/advanced-settings
 #! ---------------------------------------------------------------
 
 # Script Vendors. Set a CDN address for the vendor you want to customize.

--- a/layout/_partials/head/head-unique.swig
+++ b/layout/_partials/head/head-unique.swig
@@ -14,9 +14,10 @@
   <link rel="alternate" href="{{ url_for(theme.rss) }}" title="{{ title }}" type="application/atom+xml"/>
 {% endif %}
 
-{# Canonical, good for google search engine (SEO) : https://support.google.com/webmasters/answer/139066 #}
 {% if theme.canonical %}
-  <link rel="canonical" href="{{ config.url }}/{{ page.canonical_path.replace('index.html', '') }}"/>
+  {% set without_index = url.replace('index.html', '') %}
+  {% set without_html = without_index.replace('.html', '') %}
+  <link rel="canonical" href="{{ without_html }}"/>
 {% endif %}
 
 {# Exports some front-matter variables to Front-End #}

--- a/scripts/tags/button.js
+++ b/scripts/tags/button.js
@@ -1,5 +1,5 @@
 /**
- * button.js | https://theme-next.org/docs/tag-plugins/button/
+ * button.js | https://theme-next.org/docs/tag-plugins/button
  */
 
 /* global hexo */

--- a/scripts/tags/exturl.js
+++ b/scripts/tags/exturl.js
@@ -1,5 +1,5 @@
 /**
- * exturl.js | https://theme-next.org/docs/tag-plugins/exturl/
+ * exturl.js | https://theme-next.org/docs/tag-plugins/exturl
  * Note: need to remove in NexT v7.0.0
  */
 

--- a/scripts/tags/full-image.js
+++ b/scripts/tags/full-image.js
@@ -1,5 +1,5 @@
 /**
- * full-image.js | https://theme-next.org/docs/tag-plugins/full-image/
+ * full-image.js | https://theme-next.org/docs/tag-plugins/full-image
  */
 
 /* global hexo */

--- a/scripts/tags/group-pictures.js
+++ b/scripts/tags/group-pictures.js
@@ -1,5 +1,5 @@
 /**
- * group-pictures.js | https://theme-next.org/docs/tag-plugins/group-pictures/
+ * group-pictures.js | https://theme-next.org/docs/tag-plugins/group-pictures
  */
 
 /* global hexo */

--- a/scripts/tags/label.js
+++ b/scripts/tags/label.js
@@ -1,5 +1,5 @@
 /**
- * label.js | https://theme-next.org/docs/tag-plugins/label/
+ * label.js | https://theme-next.org/docs/tag-plugins/label
  */
 
 /* global hexo */

--- a/scripts/tags/mermaid.js
+++ b/scripts/tags/mermaid.js
@@ -1,5 +1,5 @@
 /**
- * mermaid.js | https://theme-next.org/docs/tag-plugins/mermaid/
+ * mermaid.js | https://theme-next.org/docs/tag-plugins/mermaid
  */
 
 /* global hexo */

--- a/scripts/tags/note.js
+++ b/scripts/tags/note.js
@@ -1,5 +1,5 @@
 /**
- * note.js | https://theme-next.org/docs/tag-plugins/note/
+ * note.js | https://theme-next.org/docs/tag-plugins/note
  */
 
 /* global hexo */

--- a/scripts/tags/pdf.js
+++ b/scripts/tags/pdf.js
@@ -1,5 +1,5 @@
 /**
- * pdf.js | https://theme-next.org/docs/tag-plugins/pdf/
+ * pdf.js | https://theme-next.org/docs/tag-plugins/pdf
  */
 
 /* global hexo */

--- a/scripts/tags/tabs.js
+++ b/scripts/tags/tabs.js
@@ -1,5 +1,5 @@
 /**
- * tabs.js | https://theme-next.org/docs/tag-plugins/tabs/
+ * tabs.js | https://theme-next.org/docs/tag-plugins/tabs
  */
 
 /* global hexo */

--- a/scripts/tags/video.js
+++ b/scripts/tags/video.js
@@ -1,5 +1,5 @@
 /**
- * video.js | https://theme-next.org/docs/tag-plugins/video/
+ * video.js | https://theme-next.org/docs/tag-plugins/video
  */
 
 /* global hexo */


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [x] Other... Please describe: **improvement**

## What is the current behavior?
Pages must placed in subdirectories with `index.html` names, e.g. `source/docs/troubleshooting/index.md` for pretty path with `canonical` option enabled:
![image](https://user-images.githubusercontent.com/16944225/55152876-8c539700-5151-11e9-920a-99de54c89567.png)

But if we want to use pages in root directories and named as is with `*.html` suffix, `source/docs/advanced-settings.md`, canonical path will contain `*.html` suffix:
![image](https://user-images.githubusercontent.com/16944225/55153315-6da1d000-5152-11e9-96c5-878bd6d95e7e.png)

## What is the new behavior?
From now all links will be not only without `index.html`, but without `.html` too for pretty path with `canonical` option enabled. **And not need to set `permalink` in each page for that**.

Pages now can placed in root directories and named as is with `*.html` suffix, e.g. `source/docs/advanced-settings.md`:
![image](https://user-images.githubusercontent.com/16944225/55153146-03892b00-5152-11e9-89e8-e486adff072e.png)

- Link to demo site with this changes: https://theme-next.org/docs/advanced-settings
  (with https://github.com/theme-next/theme-next.org/commit/de8fffcfb14bdab4945fe711ee6bbb2a0866ef78 and https://github.com/theme-next/theme-next.org/commit/ac9141c1eba304d9c727226b576a6822680c617d changes)
- Hexo have same behavior: https://hexo.io/docs/setup

### How to use?
In local servers `*.html` suffix will be exists. For remove they in Production, need to create redirects (for Nginx) or use advanced settings in deployment services (like «Pretty URLs» in Netlify):
![image](https://user-images.githubusercontent.com/16944225/55152504-d5efb200-5150-11e9-8dc0-92af17c10943.png)

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.