### PR TITLE
Fix Mathjax style issue

### DIFF
--- a/source/css/_common/components/third-party/math.styl
+++ b/source/css/_common/components/third-party/math.styl
@@ -2,7 +2,3 @@
   overflow-x: auto;
   overflow-y: hidden;
 }
-
-li {
-  list-style-position: inside !important;
-}

--- a/source/css/_common/components/third-party/third-party.styl
+++ b/source/css/_common/components/third-party/third-party.styl
@@ -6,4 +6,4 @@
 @import "needsharebutton" if hexo-config('needmoreshare2.enable');
 @import "related-posts" if hexo-config('related_posts.enable');
 @import "copy-code" if hexo-config('codeblock.copy_button.enable');
-@import "math" if hexo-config('math.enable');
+@import "math" if hexo-config('math.enable') and hexo-config('math.engine') == 'mathjax';


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved: #721, #736

## What is the new behavior?
<!-- Description about this pull, in several words... -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
...
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
