### PR TITLE
Removed `no-wrap` style from label tag

### DIFF
--- a/source/css/_common/components/tags/label.styl
+++ b/source/css/_common/components/tags/label.styl
@@ -1,7 +1,6 @@
 .post-body .label {
   display: inline;
   padding: 0 2px;
-  white-space: nowrap;
 
   &.default { background-color: $label-default; }
   &.primary { background-color: $label-primary; }


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/16944225/55276048-b2626e00-52ee-11e9-9d69-05a643d42379.png)

## After

![image](https://user-images.githubusercontent.com/16944225/55276055-c908c500-52ee-11e9-97f2-a05b5399dd03.png)