### PR TITLE
Install Mergeable bot which totally replaced WIP bot and have more settings

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,25 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    validate:
+      - do: description
+        no_empty:
+          enabled: false
+
+      - do: title
+        must_exclude:
+          regex: ^\[WIP\]
+
+      - do: label
+        must_exclude:
+          regex: 'wip|work in progress'
+
+      - do: project
+        no_empty:
+          enabled: true
+        must_include:
+          regex: 'feat|imp|fix|doc|chore'
+
+      - do: milestone
+        no_empty:
+          enabled: true


### PR DESCRIPTION
## Mergeable Bot

Bot used regular expressions and have a lot of settings. It's really powerful bot. More information [here](https://github.com/jusx/mergeable).

## How to Use?

For now configuration setted up only on pull requests. Settings are given below.

### Title

Can be defined in similar way as in WIP Bot:

- WIP Your Title
- WiP Your Title
- [wip] Your Title

### Label

- WiP
- Work in progress (this label will be added)

### Project

Project name which will include any of below words (regex, case-insensitive):

- feat
- imp
- fix
- doc
- chore

So, our project with «Feats. / Imprs. / Fixes» name will accepted by bot configuration.

### Milestone

Just can't be empty, but may be defined with regex too.

***

**So, WIP Bot will be removed in accordance with this PR**.