### PR TITLE
List items appeared correctly in mobile with `mobile_layout_economy` option

### DIFF
--- a/source/css/_common/scaffolding/mobile.styl
+++ b/source/css/_common/scaffolding/mobile.styl
@@ -76,8 +76,8 @@
     }
 
     // For lists narrow width.
-    > ul, > li {
-      padding: 0 18px;
+    > ul {
+       margin-inline-end: 1em;
     }
 
     // For blockquotes.


### PR DESCRIPTION
Resolved #814.

## Before
![image](https://user-images.githubusercontent.com/16944225/55646657-08964c00-57dc-11e9-9b04-7b4500385c19.png)

## After
![image](https://user-images.githubusercontent.com/16944225/55673870-10bebc00-58ae-11e9-9da9-3e2285e85cba.png)

## Without option (need to refactor in future)
![image](https://user-images.githubusercontent.com/16944225/55673879-246a2280-58ae-11e9-84f2-ea6b3b809ae3.png)
