### PR TITLE
Force include source/lib/font-awesome/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ source/lib/*
 # Track internal libraries & Ignore unused verdors files
 source/lib/font-awesome/less/
 source/lib/font-awesome/scss/
-!source/lib/font-awesome/*
+!source/lib/font-awesome/
 
 !source/lib/jquery/
 


### PR DESCRIPTION
- [ ] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] Docs in [NexT website](https://theme-next.org/docs/) have been added / updated (for new features).

> I don't know which type should be chose to describe this change, and it didn't need test.

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [x] Other... Please describe: Modified `.gitignore`

## What is the current behavior?

The origin version was `!source/lib/font-awesome/*`, but it doesn't work. While I published my blog through Travis CI, It didn't include the font-awersome lib. And my Git GUI told that the dir was excluded by .gitignore.

Issue resolved: #413

## What is the new behavior?

Now it works.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
