### PR TITLE
Fix alignments for several elements with `mobile_layout_economy` option

### DIFF
--- a/source/css/_common/scaffolding/mobile.styl
+++ b/source/css/_common/scaffolding/mobile.styl
@@ -60,12 +60,12 @@
 
   .post-body {
     // For headers narrow width.
-    h2, h3, h4, h5, h6 {
+    h1, h2, h3, h4, h5, h6 {
       margin: 10px 18px 8px;
     }
     // Rewrite paddings & margins inside tags.
     .note, .tabs .tab-content .tab-pane {
-      h2, h3, h4, h5, h6 {
+      h1, h2, h3, h4, h5, h6 {
         margin: 0 5px;
       }
     }
@@ -88,6 +88,11 @@
 
     // For external links alignment.
     > span.exturl {
+      margin-left: 18px;
+    }
+
+    // For Mist more button alignment.
+    > div.post-button a {
       margin-left: 18px;
     }
 


### PR DESCRIPTION
## Configuration

```yml
scheme: Mist
mobile_layout_economy: true
```

## Before
![image](https://user-images.githubusercontent.com/16944225/56607469-e177b100-6608-11e9-8482-31fc2954c0c0.png)

## After
![image](https://user-images.githubusercontent.com/16944225/56607688-6cf14200-6609-11e9-96ba-09f6d2237bf9.png)