### PR TITLE
Improve page rendering by deferring disqus loading

### DIFF
--- a/layout/_third-party/comments/disqus.swig
+++ b/layout/_third-party/comments/disqus.swig
@@ -1,5 +1,14 @@
 {% if theme.disqus.count %}
-  <script id="dsq-count-scr" src="https://{{ theme.disqus.shortname }}.disqus.com/count.js" async></script>
+<script>
+  function loadCount() {
+    var d = document, s = d.createElement('script');
+    s.src = 'https://{{ theme.disqus.shortname }}.disqus.com/count.js';
+    s.id = 'dsq-count-scr';
+    (d.head || d.body).appendChild(s);
+  }
+  // defer loading until the whole page loading is completed
+  window.addEventListener('load', loadCount, false);
+</script>
 {% endif %}
 {% if page.comments %}
 <script>
@@ -22,7 +31,7 @@
       var offsetTop = $('#comments').offset().top - $(window).height();
       if (offsetTop <= 0) {
         // load directly when there's no a scrollbar
-        loadComments();
+        window.addEventListener('load', loadComments, false);
       } else {
         $(window).on('scroll.disqus_scroll', function() {
           // offsetTop may changes because of manually resizing browser window or lazy loading images.
@@ -38,7 +47,7 @@
       }
     });
   {% else %}
-    loadComments();
+    window.addEventListener('load', loadComments, false);
   {% endif %}
 </script>
 {% endif %}

--- a/layout/_third-party/comments/disqusjs.swig
+++ b/layout/_third-party/comments/disqusjs.swig
@@ -8,12 +8,25 @@
 {% if theme.vendors.disqusjs_js %}
   {% set disqusjs_js_url = theme.vendors.disqusjs_js %}
 {% endif %}
-<script src="{{ disqusjs_js_url }}"></script>
 
 <script>
-  var dsqjs = new DisqusJS({
-    api: '{{ theme.disqusjs.api }}' || 'https://disqus.com/api/',
-    apikey: '{{ theme.disqusjs.apikey }}',
-    shortname: '{{ theme.disqusjs.shortname }}'
-  });
+  function initialDsq() {
+    window.dsqjs = new DisqusJS({
+      api: '{{ theme.disqusjs.api }}' || 'https://disqus.com/api/',
+      apikey: '{{ theme.disqusjs.apikey }}',
+      shortname: '{{ theme.disqusjs.shortname }}',
+      url: {{ page.permalink | json }},
+      identifier: {{ page.path | json }},
+      title: '{{ page.title | addslashes }}',
+    });
+  }
+
+  function loadDsqJS() {
+    var d = document, s = d.createElement('script');
+    s.src = '{{ disqusjs_js_url }}';
+    s.onload = initialDsq;
+    (d.head || d.body).appendChild(s);
+  }
+  
+  window.addEventListener('load', loadDsqJS, false);
 </script>


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [X] Other... Please describe: **Improvement**

## What is the current behavior?
The whole web page is blocked and shows nothing until loading `embed.js` for Disqus is completed. Things get worse when some users (especially those Chinese users) have trouble connecting Disqus since they will see a blank page for a long time until the requested timeout.

![image](https://user-images.githubusercontent.com/13927774/58751403-7c995b80-84d0-11e9-86f7-95c5fcca1810.png)

In addition, for those who enable `pace.js`, they will see the progress bar circling for a long time until timeout.

## What is the new behavior?
The main cause of this problem is that loading `*.js` for Disqus blocks the rendering of the whole web page, so I simply defer the js loading until the whole page loading is completed.

https://github.com/theme-next/hexo-theme-next/blob/54a04c6209b60b554a47f19523553b0dda3c5336/layout/_third-party/comments/disqus.swig#L10

Here I use window.onload callback function instead of directly inserting script tag to prevent blocking the whole web page.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.
