### PR TITLE
Ignore leancloud visitor from localhost

### DIFF
--- a/layout/_third-party/analytics/lean-analytics.swig
+++ b/layout/_third-party/analytics/lean-analytics.swig
@@ -103,7 +103,7 @@
             });
           };
           {% if page.layout === 'post' %}
-            const localhost = /http\:\/\/localhost|http\:\/\/127.0.0.1|http\:\/\/0.0.0.0/;
+            const localhost = /http:\/\/(localhost|127.0.0.1|0.0.0.0)/;
             if (localhost.test(document.URL)) {
               return;
             }

--- a/layout/_third-party/analytics/lean-analytics.swig
+++ b/layout/_third-party/analytics/lean-analytics.swig
@@ -103,7 +103,8 @@
             });
           };
           {% if page.layout === 'post' %}
-            if (document.URL.includes('http://localhost')) {
+            const localhost = /http\:\/\/localhost|http\:\/\/127.0.0.1|http\:\/\/0.0.0.0/;
+            if (localhost.test(document.URL)) {
               return;
             }
             addCount(Counter);

--- a/layout/_third-party/analytics/lean-analytics.swig
+++ b/layout/_third-party/analytics/lean-analytics.swig
@@ -103,6 +103,9 @@
             });
           };
           {% if page.layout === 'post' %}
+            if (document.URL.includes('http://localhost')) {
+              return;
+            }
             addCount(Counter);
           {% else %}
             if ($('.post-title-link').length >= 1) {


### PR DESCRIPTION
Use an regex to test if current `URL` includes `http://localhost` or `http://127.0.0.1` or `http://0.0.0.0` , if `true` then `return`.

If `return`, the number of visitors won't show in post and everything else is the same as before.

Issue resolved: #915