### PR TITLE
Remove unneeded leancloud-storage in `theme.vendors`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1158,12 +1158,6 @@ vendors:
   # reading_progress: //cdn.jsdelivr.net/gh/theme-next/theme-next-reading-progress@1/reading_progress.min.js
   reading_progress:
 
-  # leancloud-storage
-  # See: https://www.npmjs.com/package/leancloud-storage
-  # Example:
-  # leancloud: //cdn.jsdelivr.net/npm/leancloud-storage@3/dist/av-min.js
-  leancloud:
-
   # valine
   # See: https://github.com/xCss/Valine
   # Example:


### PR DESCRIPTION
https://github.com/theme-next/hexo-theme-next/blob/7eaf354aba8a4859e596ca9da230b894f0d61980/_config.yml#L1161-L1166

_Originally posted by @stevenjoezhang in https://github.com/theme-next/hexo-theme-next/pull/926#issuecomment-505011399_