### PR TITLE
Add z-index CSS property to `#sidebar-dimmer`

### DIFF
--- a/source/css/_common/components/sidebar/sidebar-dimmer.styl
+++ b/source/css/_common/components/sidebar/sidebar-dimmer.styl
@@ -9,6 +9,7 @@
 #sidebar-dimmer {
   show();
   position: fixed;
+  z-index: $zindex-2;
   top: 0;
   left: 100%;
   width: 100%;


### PR DESCRIPTION
`.posts-collapse` of archive pages have a z-index CSS property, this causes the option `theme.sidebar.dimmer` to not take effect on archive pages.

https://github.com/theme-next/hexo-theme-next/blob/5067852e5f5ba4883064716b530c664ec0feeafc/source/css/_common/components/post/post-collapse.styl#L17

Also the variable `$zindex-2` is not referenced by now.

https://github.com/theme-next/hexo-theme-next/blob/8ed5d6edba1485d01db4acde5dfd9a05c75feb1c/source/css/_variables/base.styl#L113
