### PR TITLE
Revert "Avoid recalculating the number of tags and categories"

### DIFF
--- a/layout/_macro/menu/menu-badge.swig
+++ b/layout/_macro/menu/menu-badge.swig
@@ -2,8 +2,8 @@
 
   {% set badges = {
     archives: site.posts.length,
-    categories: theme.visibleCategories,
-    tags: theme.visibleTags }
+    categories: site.categories.length,
+    tags: site.tags.length }
   %}
   {% for menu, count in badges %}
     {% if name == menu %}

--- a/layout/_macro/sidebar.swig
+++ b/layout/_macro/sidebar.swig
@@ -50,7 +50,7 @@
                 </div>
               {% endif %}
 
-              {% if theme.visibleCategories > 0 %}
+              {% if site.categories.length > 0 %}
                 {% set categoriesPageQuery = site.pages.find({type: 'categories'}, {lean: true}) %}
                 {% set hasCategoriesPage = categoriesPageQuery.length > 0 %}
                 <div class="site-state-item site-state-categories">
@@ -61,13 +61,17 @@
                       <a href="{{ url_for(config.category_dir) + '/' }}">
                     {% endif %}
                   {% endif %}
-                    <span class="site-state-item-count">{{ theme.visibleCategories }}</span>
+                    {% set visibleCategories = 0 %}
+                    {% for cat in site.categories %}
+                      {% if cat.length %}{% set visibleCategories += 1 %}{% endif %}
+                    {% endfor %}
+                    <span class="site-state-item-count">{{ visibleCategories }}</span>
                     <span class="site-state-item-name">{{ __('state.categories') }}</span>
                   {% if hasCategoriesPage %}</a>{% endif %}
                 </div>
               {% endif %}
 
-              {% if theme.visibleTags > 0 %}
+              {% if site.tags.length > 0 %}
                 {% set tagsPageQuery = site.pages.find({type: 'tags'}, {lean: true}) %}
                 {% set hasTagsPage = tagsPageQuery.length > 0 %}
                 <div class="site-state-item site-state-tags">
@@ -78,7 +82,11 @@
                       <a href="{{ url_for(config.tag_dir) + '/' }}">
                     {% endif %}
                   {% endif %}
-                    <span class="site-state-item-count">{{ theme.visibleTags }}</span>
+                    {% set visibleTags = 0 %}
+                    {% for tag in site.tags %}
+                      {% if tag.length %}{% set visibleTags += 1 %}{% endif %}
+                    {% endfor %}
+                    <span class="site-state-item-count">{{ visibleTags }}</span>
                     <span class="site-state-item-name">{{ __('state.tags') }}</span>
                   {% if hasTagsPage %}</a>{% endif %}
                 </div>

--- a/layout/page.swig
+++ b/layout/page.swig
@@ -33,7 +33,13 @@
         {% if page.type === 'tags' %}
           <div class="tag-cloud">
             <div class="tag-cloud-title">
-              {{ _p('counter.tag_cloud', theme.visibleTags) }}
+              {% set visibleTags = 0 %}
+              {% for tag in site.tags %}
+                {% if tag.length %}
+                  {% set visibleTags += 1 %}
+                {% endif %}
+              {% endfor %}
+              {{ _p('counter.tag_cloud', visibleTags) }}
             </div>
             <div class="tag-cloud-tags">
               {% if not theme.tagcloud %}
@@ -46,7 +52,13 @@
         {% elif page.type === 'categories' %}
           <div class="category-all-page">
             <div class="category-all-title">
-              {{ _p('counter.categories', theme.visibleCategories) }}
+              {% set visibleCategories = 0 %}
+              {% for cat in site.categories %}
+                {% if cat.length %}
+                  {% set visibleCategories += 1 %}
+                {% endif %}
+              {% endfor %}
+              {{ _p('counter.categories', visibleCategories) }}
             </div>
             <div class="category-all">
               {{ list_categories() }}

--- a/scripts/merge-configs.js
+++ b/scripts/merge-configs.js
@@ -46,20 +46,4 @@ hexo.on('generateBefore', function() {
   // Add filter type `theme_inject`
   require('./injects')(hexo);
 
-  // Fix an issue about the categories/tags count.
-  let visibleTags = 0;
-  hexo.locals.get('tags').forEach((tag) => {
-    if (tag.length) {
-      visibleTags += 1;
-    }
-  });
-  hexo.theme.config.visibleTags = visibleTags;
-  let visibleCategories = 0;
-  hexo.locals.get('categories').forEach((categorie) => {
-    if (categorie.length) {
-      visibleCategories += 1;
-    }
-  });
-  hexo.theme.config.visibleCategories = visibleCategories;
-
 });


### PR DESCRIPTION
Reverts theme-next/hexo-theme-next#954

In `generateBefore`, we can't get the count....
![image](https://user-images.githubusercontent.com/15902347/61141871-1b1dd100-a501-11e9-9ee2-b358831e29ef.png)

In `template_locals`, loop much times...
![image](https://user-images.githubusercontent.com/15902347/61141525-579cfd00-a500-11e9-8a61-c33be77b02f9.png)

Revert this submit, the best way is not use _draft, and then don't calculate them, if you have many tags or categories