### PR TITLE
Refactor post body end after custom_file_path

### DIFF
--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -330,27 +330,6 @@
     {### END POST BODY ###}
     {#####################}
 
-    {% if theme.wechat_subscriber.enable and not is_index %}
-      {% include '../_partials/post/wechat-subscriber.swig' %}
-    {% endif %}
-
-    {% if page.reward === undefined and theme.reward_settings.enable %}
-      {% set reward_able = true %}
-    {% else %}
-      {% set reward_able = page.reward %}
-    {% endif %}
-    {% if reward_able and not is_index %}
-      <div>
-        {% include '../_partials/post/reward.swig' %}
-      </div>
-    {% endif %}
-
-    {% if theme.creative_commons.license and theme.creative_commons.post and not is_index %}
-      <div>
-        {% include '../_partials/post/post-copyright.swig' with { post: post } %}
-      </div>
-    {% endif %}
-
     <footer class="post-footer">
       {% if post.tags and post.tags.length and not is_index %}
         {% if theme.tag_icon %}

--- a/layout/_partials/post/post-copyright.swig
+++ b/layout/_partials/post/post-copyright.swig
@@ -9,18 +9,20 @@
 {% endif %}
 {% set ccURL = 'https://creativecommons.org/' + ccType %}
 
+<div>
 <ul class="post-copyright">
   <li class="post-copyright-author">
     <strong>{{ __('post.copyright.author') + __('symbol.colon') }} </strong>{#
-  #}{{ post.author || author }}{#
+  #}{{ page.author || author }}{#
 #}</li>
   <li class="post-copyright-link">
     <strong>{{ __('post.copyright.link') + __('symbol.colon') }}</strong>
-    {% set postURL = post.url || post.permalink %}
-    {{ next_url(postURL, postURL, {title: post.title}) }}
+    {% set postURL = page.url || page.permalink %}
+    {{ next_url(postURL, postURL, {title: page.title}) }}
   </li>
   <li class="post-copyright-license">
     <strong>{{ __('post.copyright.license_title') + __('symbol.colon') }} </strong>{#
   #}{{ __('post.copyright.license_content', next_url(ccURL, ccIcon + ccText)) }}{#
 #}</li>
 </ul>
+</div>

--- a/scripts/filters/post-body-end/creative-commons.js
+++ b/scripts/filters/post-body-end/creative-commons.js
@@ -4,12 +4,11 @@
 
 const priority = hexo.config.inject_priority_creative_commons || 200;
 
+const path = require('path');
+
 hexo.extend.filter.register('theme_inject', function(injects) {
-  injects.postBodyEnd.raw('creative-commons', `
-  {% if theme.creative_commons.license and theme.creative_commons.post and not is_index %}
-    <div>
-      {{ partial( '_partials/post/post-copyright.swig') }}
-    </div>
-  {% endif %}
-  `);
+  let theme = hexo.theme.config;
+  if (theme.creative_commons.license && theme.creative_commons.post) {
+    injects.postBodyEnd.file('creative-commons', path.join(hexo.theme_dir, 'layout/_partials/post/post-copyright.swig'));
+  }
 }, priority);

--- a/scripts/filters/post-body-end/creative-commons.js
+++ b/scripts/filters/post-body-end/creative-commons.js
@@ -1,0 +1,15 @@
+/* global hexo */
+
+'use strict';
+
+const priority = hexo.config.inject_priority_creative_commons || 200;
+
+hexo.extend.filter.register('theme_inject', function(injects) {
+  injects.postBodyEnd.raw('creative-commons', `
+  {% if theme.creative_commons.license and theme.creative_commons.post and not is_index %}
+    <div>
+      {{ partial( '_partials/post/post-copyright.swig') }}
+    </div>
+  {% endif %}
+  `);
+}, priority);

--- a/scripts/filters/post-body-end/reward.js
+++ b/scripts/filters/post-body-end/reward.js
@@ -4,7 +4,6 @@
 
 const priority = hexo.config.inject_priority_reward || 120;
 
-// add to postBodyEnd
 hexo.extend.filter.register('theme_inject', function(injects) {
   injects.postBodyEnd.raw('reward', `
     {% if page.reward === undefined and theme.reward_settings.enable %}
@@ -17,5 +16,5 @@ hexo.extend.filter.register('theme_inject', function(injects) {
         {{ partial('_partials/post/reward.swig', {}, {cache: true}) }}
       </div>
     {% endif %}
-  `, {}, {cache: true});
+  `);
 }, priority);

--- a/scripts/filters/post-body-end/reward.js
+++ b/scripts/filters/post-body-end/reward.js
@@ -12,7 +12,7 @@ hexo.extend.filter.register('theme_inject', function(injects) {
     {% else %}
       {% set reward_able = page.reward %}
     {% endif %}
-    {% if reward_able and not is_index %}
+    {% if reward_able %}
       <div>
         {{ partial('_partials/post/reward.swig', {}, {cache: true}) }}
       </div>

--- a/scripts/filters/post-body-end/reward.js
+++ b/scripts/filters/post-body-end/reward.js
@@ -1,0 +1,21 @@
+/* global hexo */
+
+'use strict';
+
+const priority = hexo.config.inject_priority_reward || 120;
+
+// add to postBodyEnd
+hexo.extend.filter.register('theme_inject', function(injects) {
+  injects.postBodyEnd.raw('reward', `
+    {% if page.reward === undefined and theme.reward_settings.enable %}
+      {% set reward_able = true %}
+    {% else %}
+      {% set reward_able = page.reward %}
+    {% endif %}
+    {% if reward_able and not is_index %}
+      <div>
+        {{ partial('_partials/post/reward.swig', {}, {cache: true}) }}
+      </div>
+    {% endif %}
+  `, {}, {cache: true});
+}, priority);

--- a/scripts/filters/post-body-end/wechat-subscriber.js
+++ b/scripts/filters/post-body-end/wechat-subscriber.js
@@ -1,0 +1,13 @@
+/* global hexo */
+
+'use strict';
+
+const priority = hexo.config.inject_priority_wechat_subscriber || 110;
+
+const path = require('path');
+
+hexo.extend.filter.register('theme_inject', function(injects) {
+  if (hexo.theme.config.wechat_subscriber.enable) {
+    injects.postBodyEnd.file('wechat-subscriber', path.join(hexo.theme_dir, 'layout/_partials/post/wechat-subscriber.swig'), {}, {cache: true});
+  }
+}, priority);


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [x] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the new behavior?
You can adjust the position by injecting priority.

- Link to demo site with this changes: N/A
  - https://jiangtj.gitlab.io/next-test/gemini/post/hello-world/
  - https://gitlab.com/JiangTJ/next-test/commit/005ed19d54768e06aeff33b7052f1cc0e58ad65b

### How to use?
In Hexo `_config.yml` (Not NexT theme config):
```yml
inject_priority_wechat_subscriber: 110
inject_priority_reward: 120
inject_priority_creative_commons: 200
```
> custom_file_path priority is 99

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
