### PR TITLE
Return unencoded `caniuse` tag when `exturl` is enabled

### DIFF
--- a/scripts/filters/exturl.js
+++ b/scripts/filters/exturl.js
@@ -17,7 +17,7 @@ hexo.extend.filter.register('after_post_render', function(data) {
   var $ = cheerio.load(data.content, {decodeEntities: false});
   var siteHost = url.parse(config.url).hostname || config.url;
 
-  $('a').each(function() {
+  $('a').not('#non-ext').each(function() {
     var href = $(this).attr('href');
     // Exit if the href attribute doesn't exists.
     if (!href) return;

--- a/scripts/tags/caniuse.js
+++ b/scripts/tags/caniuse.js
@@ -20,3 +20,4 @@ const caniUse = (args) => {
 };
 
 hexo.extend.tag.register('caniuse', caniUse, {async: true});
+hexo.extend.tag.register('can', caniUse, {async: true});

--- a/scripts/tags/caniuse.js
+++ b/scripts/tags/caniuse.js
@@ -16,7 +16,7 @@ const caniUse = (args) => {
     return '';
   }
 
-  return `<p class="ciu_embed" data-feature="${feature}" data-periods="${periods}"><a href="http://caniuse.com/#feat=${feature}">Can I Use ${feature}?</a>Data on support for the ${feature} feature across the major browsers from caniuse.com.</p>`;
+  return `<p class="ciu_embed" data-feature="${feature}" data-periods="${periods}"><a id="non-ext" href="http://caniuse.com/#feat=${feature}">Can I Use ${feature}?</a>Data on support for the ${feature} feature across the major browsers from caniuse.com.</p>`;
 };
 
 hexo.extend.tag.register('caniuse', caniUse, {async: true});


### PR DESCRIPTION
`<p class="ciu_embed" data-feature="sharedarraybuffer" data-periods="current"><span class="exturl" data-url="aHR0cDovL2Nhbml1c2UuY29tLyNmZWF0PXNoYXJlZGFycmF5YnVmZmVy" title="http://caniuse.com/#feat=sharedarraybuffer">Can I Use sharedarraybuffer?<i class="fa fa-external-link"></i></span>Data on support for the sharedarraybuffer feature across the major browsers from caniuse.com.</p>`