### PR TITLE
Remove fastclick support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -522,10 +522,6 @@ fancybox: false
 # Dependencies: https://github.com/theme-next/theme-next-mediumzoom
 mediumzoom: false
 
-# Polyfill to remove click delays on browsers with touch UIs.
-# Dependencies: https://github.com/theme-next/theme-next-fastclick
-fastclick: false
-
 # Vanilla JavaScript plugin for lazyloading images.
 # Dependencies: https://github.com/theme-next/theme-next-lazyload
 lazyload: false
@@ -1010,13 +1006,6 @@ vendors:
   # Example:
   # mediumzoom: //cdn.jsdelivr.net/npm/medium-zoom@1/dist/medium-zoom.min.js
   mediumzoom:
-
-  # Internal version: 1.0.6
-  # See: https://github.com/ftlabs/fastclick
-  # Example:
-  # fastclick: //cdn.jsdelivr.net/npm/fastclick@1/lib/fastclick.min.js
-  # fastclick: //cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js
-  fastclick:
 
   # Internal version: 1.10.0
   # See: https://github.com/ApoorvSaxena/lozad.js

--- a/layout/_partials/head/head.swig
+++ b/layout/_partials/head/head.swig
@@ -99,7 +99,6 @@
     copycode: {{ theme.codeblock.copy_button | json_encode }},
     fancybox: {{ theme.fancybox }},
     mediumzoom: {{ theme.mediumzoom }},
-    fastclick: {{ theme.fastclick }},
     lazyload: {{ theme.lazyload }},
     pangu: {{ theme.pangu }},
     tabs: {{ theme.tabs.enable }},

--- a/layout/_scripts/vendors.swig
+++ b/layout/_scripts/vendors.swig
@@ -18,10 +18,6 @@
   {% set js_vendors.mediumzoom = 'mediumzoom/medium-zoom.min.js' %}
 {% endif %}
 
-{% if theme.fastclick %}
-  {% set js_vendors.fastclick = 'fastclick/lib/fastclick.min.js?v=1.0.6' %}
-{% endif %}
-
 {% if theme.lazyload %}
   {% set js_vendors.lazyload = 'lazyload/lozad.min.js?v=1.10.0' %}
 {% endif %}

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -8,7 +8,6 @@ $(document).ready(function() {
    */
   CONFIG.fancybox && NexT.utils.wrapImageWithFancyBox();
   CONFIG.mediumzoom && window.mediumZoom('.post-body img');
-  CONFIG.fastclick && NexT.utils.isMobile() && window.FastClick.attach(document.body);
   CONFIG.lazyload && window.lozad('.post-body img').observe();
   CONFIG.pangu && window.pangu.spacingPage();
 


### PR DESCRIPTION
## Breaking change
```diff
-fastclick: false
vendors:
-  fastclick:
```

According to the docs of fastclick:
> Note: As of late 2015 most mobile browsers - notably Chrome and Safari - no longer have a 300ms touch delay, so fastclick offers no benefit on newer browsers, and risks introducing bugs into your application. Consider carefully whether you really need to use it.

And:
https://developers.google.com/web/updates/2013/12/300ms-tap-delay-gone-away
https://juejin.im/post/5cdf84e3f265da1bb564c79a

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.
