### PR TITLE
Fix site title's external font family bug

### DIFF
--- a/layout/_partials/head/external-fonts.swig
+++ b/layout/_partials/head/external-fonts.swig
@@ -26,12 +26,12 @@
     {% set font_families += font_config.posts.family + font_styles %}
   {% endif %}
 
-  {% if font_config.logo.family and font_config.logo.external %}
+  {% if font_config.title.family and font_config.title.external %}
     {% if font_found %}
       {% set font_families += '|' %}
     {% endif %}
 
-    {% set font_families += font_config.logo.family + font_styles %}
+    {% set font_families += font_config.title.family + font_styles %}
   {% endif %}
 
   {% if font_config.codes.family and font_config.codes.external %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When we set external font family of site title, no change happens.
``` yaml
font:
  enable: true
  title:
    external: true
    family: Caveat
    size:
```
![](https://user-images.githubusercontent.com/19180725/61874330-b6a83c00-af1a-11e9-92be-fa0a0b002170.jpg)

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words... -->
We can set external font family for site title.
![](https://user-images.githubusercontent.com/19180725/61874567-4cdc6200-af1b-11e9-838d-8b9135b8589e.jpg)


- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
font:
  enable: true
  title:
    external: true
    family: Caveat
    size:
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.