### PR TITLE
Fix a bug when `theme.font` has empty family value

### DIFF
--- a/layout/_partials/head/external-fonts.swig
+++ b/layout/_partials/head/external-fonts.swig
@@ -5,6 +5,7 @@
   {% set font_display = '&display=swap' %}
   {% set font_subset = '&subset=latin,latin-ext' %}
   {% set font_styles = ':300,300italic,400,400italic,700,700italic' %}
+  {% set font_host = font_config.host | default('//fonts.googleapis.com') %}
 
   {% if font_config.global.family and font_config.global.external %}
     {% set font_global = font_config.global.family + font_styles %}
@@ -27,11 +28,31 @@
     {% set font_codes = font_config.codes.family + font_styles %}
   {% endif %}
 
+  {# Get a font list from font_config #}
   {% set font_families = [font_global, font_title, font_headings, font_posts, font_codes] %}
 
+  {# Original font list is not empty #}
   {% if font_families !== '' %}
-    {% set font_host = font_config.host | default('//fonts.googleapis.com') %}
-    <link rel="stylesheet" href="{{ font_host }}/css?family={{ String(font_families | uniq | join('|')).slice(0, -1).concat(font_display, font_subset) }}"/>
+    {# Original font list includes empty value - Some font is not setted. #}
+    {% if font_families.includes('') %}
+      {# Unique filter original font list and join `/`, then convert it to font string #}
+      {% set font_families = String(font_families | uniq | join('|')) %}
+      {# Font string ends with `|` - The last font is not setted #}
+      {% if font_families.endsWith('|') %}
+        {# Remove the unneeded last `|` from font string #}
+        {% set font_families = font_families.slice(0, -1) %}
+      {# Font string contains `||` - The font in middle part is not fully setted. #}
+      {% else %}
+        {# Replace the unneeded `||` in font string with `|` #}
+        {% set font_families = font_families.replace('||', '|') %}
+      {% endif %}
+    {# Original font list doesn't include empty value - Every font is setted. #}
+    {% else %}
+      {# Unique filter original font list and join `/`, then convert it to font string #}
+      {% set font_families = String(font_families | uniq | join('|')) %}
+    {% endif %}
+    {# Merge extra parameters to the final processed font string #}
+{##}<link rel="stylesheet" href="{{ font_host }}/css?family={{ font_families.concat(font_display, font_subset) }}"/>
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please, write pull request readme in English. Not all contributors / collaborators know Chinese and Google translate can't always translate issues accurately. Thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please, make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When `theme.font` has empty family value, the font list will contain empty value, thus resulting in the final string format being incorrect, and there are several situations.

## What is the new behavior?
<!-- Description about this pull, in several words... -->
Users could live font family value empty.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
