### PR TITLE
Strange bug with symlinked `next` dir

### DIFF
--- a/scripts/events/lib/config.js
+++ b/scripts/events/lib/config.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const merge = require('lodash/merge');
-
 module.exports = hexo => {
+  const merge = require(hexo.base_dir + 'node_modules/lodash/merge');
+
   if (hexo.locals.get) {
     var data = hexo.locals.get('data');
 


### PR DESCRIPTION
Fix for strange bug if `next` directory will be placed under symlink in `theme` → Error: Cannot find module 'lodash/merge'. Releated to #1043.

## Steps to reproduce

1. Open `hexo/themes`
2. Move `next` physical directory somewhere else, for example `/home/username`
3. Create symlink in `themes` dir: `ln -s /home/username/next hexo/themes/next-symlink`

And get something like that:

![image](https://user-images.githubusercontent.com/16944225/62456177-2d91d000-b778-11e9-82ed-9feff57f6de0.png)