### PR TITLE
Fix leancloud counter bug

### DIFF
--- a/layout/_third-party/analytics/lean-analytics.swig
+++ b/layout/_third-party/analytics/lean-analytics.swig
@@ -10,7 +10,7 @@
       var url = visitors.getAttribute('id').trim();
       var title = visitors.getAttribute('data-flag-title').trim();
 
-      Counter('get', `/classes/Counter?${JSON.stringify({ where: url })}`)
+      Counter('get', `/classes/Counter?where=${JSON.stringify({ url })}`)
         .then(response => response.json())
         .then(({ results }) => {
           if (results.length > 0) {


### PR DESCRIPTION

## PR Type

- [x] Bugfix.

## What is the current behavior?

Bug from this commit: https://github.com/theme-next/hexo-theme-next/commit/cbf604141424c9a036e249909c5b29bc014a941b#diff-d4f96cf2cea92b9d7c8d95bb034e2eb2R13 

In post page, cleancloud counter api returns all data then use the first item `var counter = results[0];`

## What is the new behavior?

In post page, cleancloud counter api returns current url correctly.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
