### PR TITLE
Expand beian options for users in mainland China

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,14 +80,22 @@ footer:
     # Version info of NexT after scheme info (vX.X.X).
     version: true
 
-  # Beian ICP information for Chinese users. See: http://www.beian.miit.gov.cn
+  # Beian ICP and gongan information for Chinese users.
+  # See: http://www.beian.miit.gov.cn
+  # See: http://www.beian.gov.cn
   beian:
     enable: false
     icp:
+    # The digit in th num of gongan beian.
+    gongan_id:
+    # The full num of gongan beian.
+    gongan_num:
+    # The icon for gongan beian. See: http://www.beian.gov.cn/portal/download
+    gongan_icon_url:
 
   # Gonganbeian information for Chinese users. See: http://www.beian.gov.cn
   gonganbeian:
-    enable: false
+    enable: true
     # The full record num of the public security.
     num:
     # The digit in record num of the public security.

--- a/_config.yml
+++ b/_config.yml
@@ -93,16 +93,6 @@ footer:
     # The icon for gongan beian. See: http://www.beian.gov.cn/portal/download
     gongan_icon_url:
 
-  # Gonganbeian information for Chinese users. See: http://www.beian.gov.cn
-  gonganbeian:
-    enable: true
-    # The full record num of the public security.
-    num:
-    # The digit in record num of the public security.
-    id:
-    # The icon for the public security record. See: http://www.beian.gov.cn/portal/download
-    url:
-
 # Creative Commons 4.0 International License.
 # See: https://creativecommons.org/share-your-work/licensing-types-examples
 # Available values of license: by | by-nc | by-nc-nd | by-nc-sa | by-nd | by-sa | zero

--- a/_config.yml
+++ b/_config.yml
@@ -80,13 +80,11 @@ footer:
     # Version info of NexT after scheme info (vX.X.X).
     version: true
 
-  # Beian ICP and gongan information for Chinese users.
-  # See: http://www.beian.miit.gov.cn
-  # See: http://www.beian.gov.cn
+  # Beian ICP and gongan information for Chinese users. See: http://www.beian.miit.gov.cn, http://www.beian.gov.cn
   beian:
     enable: false
     icp:
-    # The digit in th num of gongan beian.
+    # The digit in the num of gongan beian.
     gongan_id:
     # The full num of gongan beian.
     gongan_num:

--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,16 @@ footer:
     enable: false
     icp:
 
+  # Gonganbeian information for Chinese users. See: http://www.beian.gov.cn
+  gonganbeian:
+    enable: false
+    # The full record num of the public security.
+    num:
+    # The digit in record num of the public security.
+    id:
+    # The icon for the public security record. See: http://www.beian.gov.cn/portal/download
+    url:
+
 # Creative Commons 4.0 International License.
 # See: https://creativecommons.org/share-your-work/licensing-types-examples
 # Available values of license: by | by-nc | by-nc-nd | by-nc-sa | by-nd | by-sa | zero

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -2,7 +2,7 @@
 #}{%- set current = date(Date.now(), "YYYY") %}{#
 #}{%- if theme.footer.beian.enable %}{#
 #}{{ next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}
-  {%- if theme.footer.beian.gongan_icon_url %}<span><img src="{{ theme.footer.beian.gongan_icon_url }}" style="display:inline-block;"/></span>
+  {%- if theme.footer.beian.gongan_icon_url %}<span><img src="{{ theme.footer.beian.gongan_icon_url }}" style="display:inline-block;"/>
   {%- endif %}
   {{ next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.beian.gongan_id,
   theme.footer.beian.gongan_num + ' ') }}{#

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -1,11 +1,12 @@
 <div class="copyright">{#
 #}{%- set current = date(Date.now(), "YYYY") %}{#
 #}{%- if theme.footer.beian.enable %}{#
-#}  {{ next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}{#
+#}{{ next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}
+  {%- if theme.footer.beian.gongan_icon_url %}<span><img src="{{ theme.footer.beian.gongan_icon_url }}" style="display:inline-block;"/></span>
+  {%- endif %}
+  {{ next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.beian.gongan_id,
+  theme.footer.beian.gongan_num + ' ') }}{#
 #}{%- endif %}{#
-#}{%- if theme.footer.gonganbeian.enable %}<span><img src="{{ theme.footer.gonganbeian.url }}" style="display:inline-block;"/></span>{#
-#}  {{ next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.gonganbeian.id,
-theme.footer.gonganbeian.num + ' ') }}{#
 #}&copy; {% if theme.footer.since and theme.footer.since != current %}{{ theme.footer.since }} – {% endif %}{#
 #}<span itemprop="copyrightYear">{{ current }}</span>
   <span class="with-love" id="animate">

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -3,6 +3,9 @@
 #}{%- if theme.footer.beian.enable %}{#
 #}  {{ next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}{#
 #}{%- endif %}{#
+#}{%- if theme.footer.gonganbeian.enable %}<span><img src="{{ theme.footer.gonganbeian.url }}" style="display:inline-block;"/></span>{#
+#}  {{ next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.gonganbeian.id,
+theme.footer.gonganbeian.num + ' ') }}{#
 #}&copy; {% if theme.footer.since and theme.footer.since != current %}{{ theme.footer.since }} – {% endif %}{#
 #}<span itemprop="copyrightYear">{{ current }}</span>
   <span class="with-love" id="animate">


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [X] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No feature of the public security record.

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words... -->
For Chinese users, except for the ICP record, they need public security record, too. I added this feature in this pull request.

- Screenshots with this changes: 
![](http://resources.matalking.com/20190823170036.png!matalking_1)

- Link to demo site with this changes: [https://www.matalking.com/](https://www.matalking.com/)

### How to use?
In NexT `_config.yml`:
```yml
footer:
  beian:
    enable: true
    icp: 京ICP备19031359号-2
    gongan_id: 11010502038639
    gongan_num: 京公网安备 11010502038639号
    gongan_icon_url: /uploads/beian.png
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.
