### PR TITLE
Add order for theme_inject

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -608,11 +608,15 @@ comments:
   active:
   # Setting `true` means remembering the comment system selected by the visitor.
   storage: true
-  # Modify icons and texts for any style, here are some examples.
+  # Modify texts or order for any navs, here are some examples.
   nav:
-    #disqus: disqus
-    #facebook_comments_plugin: <i class="fa fa-facebook-official" aria-hidden="true"></i> facebook
-    #gitalk: Load Gitalk
+    #disqus:
+    #  text: Load Disqus
+    #  order: -1
+    #facebook_comments_plugin:
+    #  text: <i class="fa fa-facebook-official" aria-hidden="true"></i> facebook
+    #gitalk:
+    #  order: -2
 
 # Disqus
 disqus:
@@ -620,6 +624,7 @@ disqus:
   shortname:
   count: true
   lazyload: false
+  #post_meta_order: 0
 
 # DisqusJS
 # Alternative Disqus - Render comment component using Disqus API.
@@ -641,6 +646,7 @@ changyan:
   enable: false
   appid:
   appkey:
+  #post_meta_order: 0
 
 # Valine
 # You can get your appid and appkey from https://leancloud.cn
@@ -658,6 +664,7 @@ valine:
   language: # Language, available values: en, zh-cn
   visitor: false # leancloud-counter-security is not supported for now. When visitor is set to be true, appid and appkey are recommended to be the same as leancloud_visitors' for counter compatibility. Article reading statistic https://valine.js.org/visitor.html
   comment_count: true # If false, comment count will only be displayed in post page, not in home page
+  #post_meta_order: 0
 
 # LiveRe comments system
 # You can get your uid from https://livere.com/insight/myCode (General web site)
@@ -701,6 +708,7 @@ facebook_comments_plugin:
   num_of_posts: 10    # Minimum posts num is 1
   width:        100%  # Default width is 550px
   scheme:       light # Default scheme is light (light or dark)
+  #post_meta_order: 0
 
 # VKontakte API Support
 # To get your AppID visit https://vk.com/editapp?act=create

--- a/scripts/events/lib/injects.js
+++ b/scripts/events/lib/injects.js
@@ -20,14 +20,10 @@ class ViewInject {
     this.raws = [];
   }
   raw(name, raw, ...args) {
-    this.raws.push({
-      name,
-      raw,
-      args
-    });
+    this.raws.push({name, raw, args});
   }
   file(name, file, ...args) {
-    this.raw.apply(this, [name, fs.readFileSync(file).toString()].concat(args));
+    this.raw(name, fs.readFileSync(file, 'utf8'), ...args);
   }
 }
 
@@ -56,19 +52,24 @@ module.exports = hexo => {
 
   // Inject views
   points.views.forEach(type => {
+    let configs = Object.create(null);
     hexo.theme.config.injects[type] = [];
-    injects[type].raws.forEach(injectObj => {
-      // If there is no suffix, will add `.swig`
+    injects[type].raws.forEach((injectObj, index) => {
+      // If there is no suffix, will add `.swig`.
       if (injectObj.name.indexOf('.') < 0) {
         injectObj.name += '.swig';
       }
-      let viewName = `inject/${type}/${injectObj.name}`;
-      hexo.theme.setView(viewName, injectObj.raw);
-      hexo.theme.config.injects[type].push({
-        layout : viewName,
+      let name = `inject/${type}/${injectObj.name}`;
+      // Add or override view.
+      hexo.theme.setView(name, injectObj.raw);
+      configs[name] = {
+        layout : name,
         locals : injectObj.args[0],
-        options: injectObj.args[1]
-      });
+        options: injectObj.args[1],
+        order  : injectObj.args[2] || index
+      };
     });
+    hexo.theme.config.injects[type] = Object.values(configs)
+      .sort((x, y) => x.order - y.order);
   });
 };

--- a/scripts/filters/comment/changyan.js
+++ b/scripts/filters/comment/changyan.js
@@ -4,7 +4,6 @@
 
 const path = require('path');
 const {iconText} = require('./common');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -19,7 +18,7 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('changyan', path.join(hexo.theme_dir, 'layout/_third-party/comments/changyan.swig'));
 
-}, priority.changyan);
+});
 
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
@@ -41,6 +40,6 @@ hexo.extend.filter.register('theme_inject', injects => {
     {% endif %}
   </span>
   {% endif %}
-  `);
+  `, {}, {}, theme.changyan.post_meta_order);
 
-}, priority.changyan_post_meta);
+});

--- a/scripts/filters/comment/default-config.js
+++ b/scripts/filters/comment/default-config.js
@@ -22,9 +22,12 @@ hexo.extend.filter.register('theme_inject', injects => {
     }
     // Set custom button content
     if (config.nav) {
-      let customButton = config.nav[locals.configKey];
-      if (customButton) {
-        locals.button = customButton;
+      let nav = config.nav[locals.configKey] || {};
+      if (nav.order) {
+        element.args[2] = nav.order;
+      }
+      if (nav.text) {
+        locals.button = nav.text;
       }
     }
   });

--- a/scripts/filters/comment/disqus.js
+++ b/scripts/filters/comment/disqus.js
@@ -4,7 +4,6 @@
 
 const path = require('path');
 const {iconText} = require('./common');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -23,7 +22,7 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('disqus', path.join(hexo.theme_dir, 'layout/_third-party/comments/disqus.swig'));
 
-}, priority.disqus);
+});
 
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
@@ -39,6 +38,6 @@ hexo.extend.filter.register('theme_inject', injects => {
     #}</a>
   </span>
   {% endif %}
-  `);
+  `, {}, {}, theme.disqus.post_meta_order);
 
-}, priority.disqus_post_meta);
+});

--- a/scripts/filters/comment/disqusjs.js
+++ b/scripts/filters/comment/disqusjs.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const path = require('path');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -22,4 +21,4 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('disqusjs', path.join(hexo.theme_dir, 'layout/_third-party/comments/disqusjs.swig'));
 
-}, priority.disqusjs);
+});

--- a/scripts/filters/comment/facebook-comments-plugin.js
+++ b/scripts/filters/comment/facebook-comments-plugin.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const {iconText} = require('./common');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -24,7 +23,7 @@ hexo.extend.filter.register('theme_inject', injects => {
     button   : '<i class="fa fa-facebook-official" aria-hidden="true"></i> facebook'
   });
 
-}, priority.facebook_comments_plugin);
+});
 
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
@@ -40,6 +39,6 @@ hexo.extend.filter.register('theme_inject', injects => {
     #}</a>
   </span>
   {% endif %}
-  `);
+  `, {}, {}, theme.facebook_comments_plugin.post_meta_order);
 
-}, priority.facebook_comments_plugin_post_meta);
+});

--- a/scripts/filters/comment/gitalk.js
+++ b/scripts/filters/comment/gitalk.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const path = require('path');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -14,4 +13,4 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('gitalk', path.join(hexo.theme_dir, 'layout/_third-party/comments/gitalk.swig'));
 
-}, priority.gitalk);
+});

--- a/scripts/filters/comment/livere.js
+++ b/scripts/filters/comment/livere.js
@@ -3,7 +3,6 @@
 'use strict';
 
 const path = require('path');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -18,4 +17,4 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('livere', path.join(hexo.theme_dir, 'layout/_third-party/comments/livere.swig'));
 
-}, priority.livere);
+});

--- a/scripts/filters/comment/valine.js
+++ b/scripts/filters/comment/valine.js
@@ -4,7 +4,6 @@
 
 const path = require('path');
 const {iconText} = require('./common');
-const priority = hexo.config.inject_priority || {};
 
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
@@ -15,7 +14,7 @@ hexo.extend.filter.register('theme_inject', injects => {
 
   injects.bodyEnd.file('valine', path.join(hexo.theme_dir, 'layout/_third-party/comments/valine.swig'));
 
-}, priority.valine);
+});
 
 // Add post_meta
 hexo.extend.filter.register('theme_inject', injects => {
@@ -31,6 +30,6 @@ hexo.extend.filter.register('theme_inject', injects => {
     #}</a>
   </span>
   {% endif %}
-  `);
+  `, {}, {}, theme.valine.post_meta_order);
 
-}, priority.valine_post_meta);
+});

--- a/scripts/filters/comment/vkontakte.js
+++ b/scripts/filters/comment/vkontakte.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-const priority = hexo.config.inject_priority || {};
-
 // Add comment
 hexo.extend.filter.register('theme_inject', injects => {
   let theme = hexo.theme.config;
@@ -14,4 +12,4 @@ hexo.extend.filter.register('theme_inject', injects => {
     button   : '<i class="fa fa-vk" aria-hidden="true"></i> vkontakte'
   }, {cache: true});
 
-}, priority.vkontakte_comments_plugin);
+});


### PR DESCRIPTION
## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Order of theme_inject is only determined by the priority of the injection.

## What is the new behavior?
Order of theme_inject is determined by the priority of the injection or special configuration in inject api.

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.

Redesigned the sequential configuration of the multi-comment system.

```diff
# Multiple Comment System Support
comments:
  # Available values: tabs | buttons
  style: tabs
  # Choose a comment system to be displayed by default.
  # Available values: changyan | disqus | disqusjs | facebook_comments_plugin | gitalk | livere | valine | vkontakte
  active:
  # Setting `true` means remembering the comment system selected by the visitor.
  storage: true
  # Modify texts or order for any navs, here are some examples.
  nav:
-    #disqus: disqus
-    #facebook_comments_plugin: <i class="fa fa-facebook-official" aria-hidden="true"></i> facebook
-    #gitalk: Load Gitalk
+    #disqus:
+    #  text: Load Disqus
+    #  order: -1
+    #facebook_comments_plugin:
+    #  text: <i class="fa fa-facebook-official" aria-hidden="true"></i> facebook
+    #gitalk:
+    #  order: -2
```


