### PR TITLE
Add container for busuanzi counter widget

### DIFF
--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -125,7 +125,7 @@
           {%- endif %}
 
           {%- if not is_index and theme.busuanzi_count.enable and theme.busuanzi_count.post_views %}
-            <span class="post-meta-item" title="{{ __('post.views') }}">
+            <span class="post-meta-item" title="{{ __('post.views') }}" id="busuanzi_container_page_pv" style='display:none'>
               <span class="post-meta-item-icon">
                 <i class="fa fa-{{ theme.busuanzi_count.post_views_icon }}"></i>
               </span>

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -125,7 +125,7 @@
           {%- endif %}
 
           {%- if not is_index and theme.busuanzi_count.enable and theme.busuanzi_count.post_views %}
-            <span class="post-meta-item" title="{{ __('post.views') }}" id="busuanzi_container_page_pv" style='display:none'>
+            <span class="post-meta-item" title="{{ __('post.views') }}" id="busuanzi_container_page_pv" style="display: none;">
               <span class="post-meta-item-icon">
                 <i class="fa fa-{{ theme.busuanzi_count.post_views_icon }}"></i>
               </span>

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -130,7 +130,7 @@
                 <i class="fa fa-{{ theme.busuanzi_count.post_views_icon }}"></i>
               </span>
               <span class="post-meta-item-text">{{ __('post.views') + __('symbol.colon') }}</span>
-              <span class="busuanzi-value" id="busuanzi_value_page_pv"></span>
+              <span id="busuanzi_value_page_pv"></span>
             </span>
           {%- endif %}
 

--- a/layout/_partials/analytics/busuanzi-counter.swig
+++ b/layout/_partials/analytics/busuanzi-counter.swig
@@ -3,7 +3,7 @@
   <script{{ pjax }} async src="https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 
   {%- if theme.busuanzi_count.total_visitors %}
-    <span class="post-meta-item" id="busuanzi_container_site_uv" style='display:none'>
+    <span class="post-meta-item" id="busuanzi_container_site_uv" style="display: none;">
       <span class="post-meta-item-icon">
         <i class="fa fa-{{ theme.busuanzi_count.total_visitors_icon }}"></i>
       </span>
@@ -18,7 +18,7 @@
   {%- endif %}
 
   {%- if theme.busuanzi_count.total_views %}
-    <span class="post-meta-item" id="busuanzi_container_site_pv" style='display:none'>
+    <span class="post-meta-item" id="busuanzi_container_site_pv" style="display: none;">
       <span class="post-meta-item-icon">
         <i class="fa fa-{{ theme.busuanzi_count.total_views_icon }}"></i>
       </span>

--- a/layout/_partials/analytics/busuanzi-counter.swig
+++ b/layout/_partials/analytics/busuanzi-counter.swig
@@ -8,7 +8,7 @@
         <i class="fa fa-{{ theme.busuanzi_count.total_visitors_icon }}"></i>
       </span>
       <span class="site-uv" title="{{ __('footer.total_visitors') }}">
-        <span class="busuanzi-value" id="busuanzi_value_site_uv"></span>
+        <span id="busuanzi_value_site_uv"></span>
       </span>
     </span>
   {%- endif %}
@@ -23,7 +23,7 @@
         <i class="fa fa-{{ theme.busuanzi_count.total_views_icon }}"></i>
       </span>
       <span class="site-pv" title="{{ __('footer.total_views') }}">
-        <span class="busuanzi-value" id="busuanzi_value_site_pv"></span>
+        <span id="busuanzi_value_site_pv"></span>
       </span>
     </span>
   {%- endif %}

--- a/layout/_partials/analytics/busuanzi-counter.swig
+++ b/layout/_partials/analytics/busuanzi-counter.swig
@@ -3,11 +3,13 @@
   <script{{ pjax }} async src="https://busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js"></script>
 
   {%- if theme.busuanzi_count.total_visitors %}
-    <span class="post-meta-item-icon">
-      <i class="fa fa-{{ theme.busuanzi_count.total_visitors_icon }}"></i>
-    </span>
-    <span class="site-uv" title="{{ __('footer.total_visitors') }}">
-      <span class="busuanzi-value" id="busuanzi_value_site_uv"></span>
+    <span class="post-meta-item" id="busuanzi_container_site_uv" style='display:none'>
+      <span class="post-meta-item-icon">
+        <i class="fa fa-{{ theme.busuanzi_count.total_visitors_icon }}"></i>
+      </span>
+      <span class="site-uv" title="{{ __('footer.total_visitors') }}">
+        <span class="busuanzi-value" id="busuanzi_value_site_uv"></span>
+      </span>
     </span>
   {%- endif %}
 
@@ -16,11 +18,13 @@
   {%- endif %}
 
   {%- if theme.busuanzi_count.total_views %}
-    <span class="post-meta-item-icon">
-      <i class="fa fa-{{ theme.busuanzi_count.total_views_icon }}"></i>
-    </span>
-    <span class="site-pv" title="{{ __('footer.total_views') }}">
-      <span class="busuanzi-value" id="busuanzi_value_site_pv"></span>
+    <span class="post-meta-item" id="busuanzi_container_site_pv" style='display:none'>
+      <span class="post-meta-item-icon">
+        <i class="fa fa-{{ theme.busuanzi_count.total_views_icon }}"></i>
+      </span>
+      <span class="site-pv" title="{{ __('footer.total_views') }}">
+        <span class="busuanzi-value" id="busuanzi_value_site_pv"></span>
+      </span>
     </span>
   {%- endif %}
 </div>


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [X] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [X] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [ ] Bugfix.
- [X] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved: N/A

For `busuanzi` counter, if the script is not correctly loaded and executed, the display would be broken. Example:

```
阅读次数:   // here is supposed to be the page_pv counter value.
```

## What is the new behavior?
<!-- Description about this pull, in several words... -->

For `busuanzi` counter, if the script is not correctly loaded and executed, the container `span` will remain hidden, rather than broken display.

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?

Automatically enable, if `busuanzi` is enabled.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [X] No.
