### PR TITLE
Fix fancybox & medium-zoom for hexo asset_img tag

### DIFF
--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -80,7 +80,7 @@ NexT.boot.refresh = function() {
    * Need to add config option in Front-End at 'layout/_partials/head.swig' file.
    */
   CONFIG.fancybox && NexT.utils.wrapImageWithFancyBox();
-  CONFIG.mediumzoom && window.mediumZoom('.post-body :not(a) > img');
+  CONFIG.mediumzoom && window.mediumZoom('.post-body :not(a) > img, .post-body > img');
   CONFIG.lazyload && window.lozad('.post-body img').observe();
   CONFIG.pangu && window.pangu.spacingPage();
 

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -20,7 +20,7 @@ NexT.utils = {
    * Wrap images with fancybox.
    */
   wrapImageWithFancyBox: function() {
-    document.querySelectorAll('.post-body :not(a) > img').forEach(element => {
+    document.querySelectorAll('.post-body :not(a) > img, .post-body > img').forEach(element => {
       var $image = $(element);
       var imageLink = $image.attr('data-src') || $image.attr('src');
       var $imageWrapLink = $image.wrap(`<a class="fancybox fancybox.image" href="${imageLink}" itemscope itemtype="http://schema.org/ImageObject" itemprop="url"></a>`).parent('a');


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.
-->

## PR Checklist
**Please check if your PR fulfills the following requirements:**
<!-- Change [ ] to [X] to select -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Mist have been tested.
   - [x] Pisces have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
**What kind of change does this PR introduce?**

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue resolved: N/A

If I use hexo [tag plugins](https://hexo.io/docs/tag-plugins.html#Include-Assets) to insert an image, it will not be rendered as medium zoom style.

i.e. `{% asset_img 2222.jpg  %}`

## What is the new behavior?
<!-- Description about this pull, in several words... -->

Medium zoom take effects on images whether imported with hexo `asset_img` tag or markdown-style `![](image.jpg)`.

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?

Just set true.

In NexT `_config.yml`:
```yml
mediumzoom: true
```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
