### PR TITLE
auto-dark-mode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,6 +113,15 @@ scheme: Muse
 #scheme: Pisces
 #scheme: Gemini
 
+# ---------------------------------------------------------------
+# Auto Dark Mode Settings
+# ---------------------------------------------------------------
+
+# If turned on, the background color and text color will change automatically according to user's system setting
+# It's recommend to change codeblock section to dark theme as well
+# Suppurted browsers: https://caniuse.com/#search=prefers-color-scheme
+auto_dark_mode:
+  enable: true
 
 # ---------------------------------------------------------------
 # Menu Settings

--- a/source/css/_common/components/third-party/search.styl
+++ b/source/css/_common/components/third-party/search.styl
@@ -34,6 +34,13 @@
     width: 100%;
   }
 
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+      color: $text-color-dark;
+    }
+  }
+
   .search-icon, .popup-btn-close {
     color: $grey-dark;
     display: inline-block;

--- a/source/css/_common/scaffolding/base.styl
+++ b/source/css/_common/scaffolding/base.styl
@@ -19,6 +19,13 @@ body {
     padding-left: 0 !important;
     padding-right: 0 !important;
   }
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-dark;
+      color: $text-color-dark;
+    }
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/source/css/_common/scaffolding/comments.styl
+++ b/source/css/_common/scaffolding/comments.styl
@@ -33,6 +33,12 @@
   margin-top: 4em;
   padding-top: 0;
 
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+    }
+  }
+
   .comments {
     border: 0;
     box-shadow: none;

--- a/source/css/_mixins/base.styl
+++ b/source/css/_mixins/base.styl
@@ -91,3 +91,9 @@ disable-user-select() {
   -webkit-user-select: none;
   user-select: none;
 }
+
+auto-dark-mode() {
+  @media (prefers-color-scheme: dark) {
+    {block}
+  }
+}

--- a/source/css/_schemes/Gemini/index.styl
+++ b/source/css/_schemes/Gemini/index.styl
@@ -39,6 +39,12 @@ $use-seo = hexo-config('seo');
   border-radius: $border-radius-inner;
   box-shadow: $box-shadow-inner;
   padding: $content-desktop-padding;
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+    }
+  }
 }
 
 // When blocks are siblings (homepage).
@@ -57,6 +63,13 @@ $use-seo = hexo-config('seo');
   margin: auto;
   margin-top: $sidebar-offset;
   padding: $content-desktop-padding;
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-dark;
+      color: $text-color-dark;
+    }
+  }
 }
 
 .tabs-comment {

--- a/source/css/_schemes/Muse/_menu.styl
+++ b/source/css/_schemes/Muse/_menu.styl
@@ -7,6 +7,12 @@
     padding: 0;
     width: 100%;
   }
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+    }
+  }
 }
 
 .site-nav-toggle {

--- a/source/css/_schemes/Pisces/_layout.styl
+++ b/source/css/_schemes/Pisces/_layout.styl
@@ -35,6 +35,13 @@
     position: relative;
     width: auto;
   }
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+      color: $text-color-dark;
+    }
+  }
 }
 
 .main {
@@ -55,6 +62,12 @@
   float: right;
   padding: $content-desktop-padding;
   width: $content-wrap;
+
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+    }
+  }
 
   +tablet-mobile() {
     border-radius: initial;

--- a/source/css/_schemes/Pisces/_menu.styl
+++ b/source/css/_schemes/Pisces/_menu.styl
@@ -23,6 +23,12 @@
 .menu-item-active a {
   background: $whitesmoke;
 
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $grey;
+    }
+  }
+
   if (!hexo-config('menu_settings.badges')) {
     &::after {
       background: $grey;

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -24,6 +24,13 @@
     opacity: 0;
   }
 
+  if (hexo-config('auto_dark_mode.enable')) {
+    +auto-dark-mode() {
+      background: $body-bg-color-darkgrey;
+      color: $text-color-dark;
+    }
+  }
+
   &.affix {
     position: fixed;
     top: $sidebar-offset;

--- a/source/css/_schemes/Pisces/_sub-menu.styl
+++ b/source/css/_schemes/Pisces/_sub-menu.styl
@@ -28,6 +28,12 @@
     background: white;
     border-bottom-color: $sidebar-highlight;
     color: $sidebar-highlight;
+ 
+    if (hexo-config('auto_dark_mode.enable')) {
+      +auto-dark-mode() {
+        background: $grey;
+      }
+    }
 
     &:hover {
       background: white;

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -16,6 +16,7 @@ $grey-dim     = #666;
 $black-light  = #555;
 $black-dim    = #333;
 $black-deep   = #222;
+$dark-grey    = #121212;
 $red          = #ff2a2a;
 $blue-bright  = #87daff;
 $blue         = #0684bd;
@@ -28,6 +29,7 @@ $orange       = #fc6423;
 // --------------------------------------------------
 // Global text color on <body>
 $text-color                   = $black-light;
+$text-color-dark              = $grey-light;
 
 // Global link color.
 $link-color                   = $black-light;
@@ -40,6 +42,8 @@ $border-color                 = $grey-light;
 
 // Background color for <body>
 $body-bg-color                = white;
+$body-bg-color-dark           = black;
+$body-bg-color-darkgrey       = $dark-grey;
 
 // Selection
 $selection-bg                 = $blue-deep;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).

## PR Type
- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?
Add new darkmode feature, allowing devices running latest OS with dark mode option to switch UI.

### How to use?
In NexT `_config.yml`:
```yml
# ---------------------------------------------------------------
# Auto Dark Mode Settings
# ---------------------------------------------------------------

# If turned on, the background color and text color will change automatically according to user's system setting
# It's recommend to change codeblock section to dark theme as well
# Suppurted browsers: https://caniuse.com/#search=prefers-color-scheme
auto_dark_mode:
  enable: true
```

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.
