### PR TITLE
Modify the order of the links before and after the article at the bot…

### DIFF
--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -257,24 +257,23 @@
 
         {%- if post.prev or post.next %}
           <div class="post-nav">
+          <!--It must still be set to "post-nav-next", 
+              otherwise the order of the arrow and link text will be reversed.
+          -->
             <div class="post-nav-next post-nav-item">
-              {%- if post.next %}
-                <a href="{{ url_for(post.next.path) }}" rel="next" title="{{ post.next.title }}">
-                  <i class="fa fa-chevron-left"></i> {{ post.next.title }}
-                </a>
-              {%- endif %}
+              {% if post.prev %}
+ 					      <a href="{{ url_for(post.prev.path) }}" rel="prev" title="{{ post.prev.title }}"><i class="fa fa-chevron-left"></i> {{ post.prev.title }}</a>
+              {% endif %}
             </div>
 
             <span class="post-nav-divider"></span>
 
             <div class="post-nav-prev post-nav-item">
-              {%- if post.prev %}
-                <a href="{{ url_for(post.prev.path) }}" rel="prev" title="{{ post.prev.title }}">
-                  {{ post.prev.title }} <i class="fa fa-chevron-right"></i>
-                </a>
-              {%- endif %}
+              {% if post.next %}
+                <a href="{{ url_for(post.next.path) }}" rel="prev" title="{{ post.next.title }}">{{ post.next.title }} <i class="fa fa-chevron-right"></i></a>
+              {% endif %}
             </div>
-          </div>
+		      </div>
         {%- endif %}
       </footer>
     {% else %}


### PR DESCRIPTION
…tom of the page

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
cd path/to/theme-next
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.

5. Please check if your PR fulfills the following requirements.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select, not [ x] or [x ] (将 [ ] 换成 [x] 来选择，而非 [ x] 或者 [x ]) -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
- `I found that there is a problem with the order of the links before and after the page. The link to the previous article should be displayed on the left under normal circumstances and now on the right.`

## What is the new behavior?
<!-- Description about this pull, in several words -->
- `I modified the post.swig file under "layout/_macro/". The specific modification is the code snippet under "{% if not is_index and (post.prev or post.next) %}"`
- Screenshots with this changes: ![](https://perry96.com/imgs/hexo/hexo-post-next-b.png)
- Link to demo site with this changes: https://perry96.com/archives/531cca2c.html

### How to use?
In NexT `_config.yml`:
```yml

```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
