### PR TITLE
Make author image optional

### DIFF
--- a/layout/_partials/sidebar/site-overview.swig
+++ b/layout/_partials/sidebar/site-overview.swig
@@ -1,8 +1,7 @@
 <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
   {%- if theme.avatar.url %}
-    <img class="site-author-image" itemprop="image"
-      src="{{ url_for( theme.avatar.url | default(theme.images + '/avatar.gif') ) }}"
-      alt="{{ author }}">
+    <img class="site-author-image" itemprop="image" alt="{{ author }}"
+      src="{{ url_for(theme.avatar.url) }}">
   {%- endif %}
   <p class="site-author-name" itemprop="name">{{ author }}</p>
   <div class="site-description" itemprop="description">{{ description }}</div>

--- a/layout/_partials/sidebar/site-overview.swig
+++ b/layout/_partials/sidebar/site-overview.swig
@@ -1,6 +1,9 @@
 <div class="site-author motion-element" itemprop="author" itemscope itemtype="http://schema.org/Person">
-  <img class="site-author-image" itemprop="image" alt="{{ author }}"
-    src="{{ url_for(theme.avatar.url or theme.images + '/avatar.gif') }}">
+  {%- if theme.avatar.url %}
+    <img class="site-author-image" itemprop="image"
+      src="{{ url_for( theme.avatar.url | default(theme.images + '/avatar.gif') ) }}"
+      alt="{{ author }}">
+  {%- endif %}
   <p class="site-author-name" itemprop="name">{{ author }}</p>
   <div class="site-description" itemprop="description">{{ description }}</div>
 </div>


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select, not [ x] or [x ] (将 [ ] 换成 [x] 来选择，而非 [ x] 或者 [x ]) -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [X] Tests for the changes was maked (for bug fixes / features).
   - [X] Muse | Mist have been tested.
   - [X] Pisces | Gemini have been tested.
- [X] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [X] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
Currently in docs there is a behavior that includes doesn't show author image when is not present. But even not present im YAML an image is rendering.

Issue resolved: N/A

## What is the new behavior?
Author image is showing only there is a author image on YAML.

- Screenshots with this changes:
![Seleção_001](https://user-images.githubusercontent.com/6884466/68335597-85174300-00bb-11ea-9792-38fbb5ed7253.png)

- Link to demo site with this changes: 
https://www.geresdev.com.br/

### How to use?
In Hexo `next.yml` don't include avatar.url

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
