### PR TITLE
Set inject default extname from file's extname

### DIFF
--- a/scripts/events/lib/injects.js
+++ b/scripts/events/lib/injects.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const points = require('./injects-point');
+const defaultExtname = '.swig';
 
 // Defining stylus types
 class StylusInject {
@@ -23,9 +24,17 @@ class ViewInject {
     this.raws = [];
   }
   raw(name, raw, ...args) {
+    // Set default extname
+    if (path.extname(name) === '') {
+      name += defaultExtname;
+    }
     this.raws.push({name, raw, args});
   }
   file(name, file, ...args) {
+    // Set default extname from file's extname
+    if (path.extname(name) === '') {
+      name += path.extname(file);
+    }
     // Get absolute path base on hexo dir
     this.raw(name, fs.readFileSync(path.resolve(this.base_dir, file), 'utf8'), ...args);
   }
@@ -58,13 +67,9 @@ module.exports = hexo => {
   points.views.forEach(type => {
     let configs = Object.create(null);
     hexo.theme.config.injects[type] = [];
+    // Add or override view.
     injects[type].raws.forEach((injectObj, index) => {
-      // If there is no suffix, `.swig` will be added
-      if (injectObj.name.indexOf('.') < 0) {
-        injectObj.name += '.swig';
-      }
       let name = `inject/${type}/${injectObj.name}`;
-      // Add or override view.
       hexo.theme.setView(name, injectObj.raw);
       configs[name] = {
         layout : name,
@@ -73,6 +78,7 @@ module.exports = hexo => {
         order  : injectObj.args[2] || index
       };
     });
+    // Views sort.
     hexo.theme.config.injects[type] = Object.values(configs)
       .sort((x, y) => x.order - y.order);
   });


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select, not [ x] or [x ] (将 [ ] 换成 [x] 来选择，而非 [ x] 或者 [x ]) -->

- [x] The commit message follows [our guidelines](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
If there is no extension, will add `.swig`.

## What is the new behavior?
If there is no extension, will add file's extname or `.swig`.

e.g. use md extname https://gitlab.com/JiangTJ/next-test/blob/master/scripts/fix-scheme.js#L15-17
![image](https://user-images.githubusercontent.com/15902347/69306230-c84be700-0c61-11ea-8501-06c7f2f30186.png)
![image](https://user-images.githubusercontent.com/15902347/69306240-cf72f500-0c61-11ea-9ea0-19956c879a38.png)

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
