### PR TITLE
Refactor js cdn to support jsdelivr

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -1,0 +1,56 @@
+name: Performance Test
+
+on: [push]
+
+jobs:
+  run:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x,12.x,13.x]
+
+    steps:
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Checkout theme
+      uses: actions/checkout@v1
+      with:
+        path: themes/next
+    - name: Run test
+      run: |
+        cd ../../
+        npm install -g hexo-cli
+        hexo init test
+        mv themes/next test/themes/next
+        cd test
+        git clone https://github.com/theme-next/hexo-many-posts.git --depth=1 --quiet source/_posts/skk
+        git clone https://github.com/theme-next/performance-test.git --depth=1 --quiet sh
+        git clone https://github.com/theme-next/hexo-theme-next.git --depth=1 --quiet themes/next-master
+
+        echo '-----------------------------'
+        echo 'Test current branch performance'
+        echo '-----------------------------'
+        hexo config theme next
+        sh ./sh/perf-test.sh
+        sh ./sh/perf-test.sh
+        echo ''
+
+        echo '-----------------------------'
+        echo 'Test master branch performance'
+        echo '-----------------------------'
+        hexo config theme next-master
+        sh ./sh/perf-test.sh
+        sh ./sh/perf-test.sh
+        echo ''
+
+        echo '-----------------------------'
+        echo 'Test default theme performance'
+        echo '-----------------------------'
+        hexo config theme landscape
+        sh ./sh/perf-test.sh
+        sh ./sh/perf-test.sh
+        echo ''

--- a/_config.yml
+++ b/_config.yml
@@ -808,7 +808,7 @@ tabs:
 
 # PDF tag, requires two plugins: pdfObject and pdf.js
 # pdfObject will try to load pdf files natively, if failed, pdf.js will be used.
-# The following `cdn` setting is only for pdfObject, because cdn for pdf.js might be blocked by CORS policy.
+# The following `cdn` setting is only for pdfObject, because CDN for pdf.js might be blocked by CORS policy.
 # So, you must install the dependency of pdf.js if you want to use pdf tag and make it available to all browsers.
 # See: https://github.com/theme-next/theme-next-pdf
 pdf:
@@ -1026,10 +1026,10 @@ vendors:
 
 # Assets
 css: css
-# set js cdn
+# Set js CDN
 # ${version} will be replaced by next-version e.g. 7.6.0
 # ${file} be replaced by file name e.g. next-boot.js
-# if you want to use jsdelivr, can config as follow (should use release version, not master)
+# If you want to use jsDelivr, you can configure it as follow (should use release version, not master)
 # js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}
 js: js/${file}
 images: images

--- a/_config.yml
+++ b/_config.yml
@@ -1028,3 +1028,9 @@ vendors:
 css: css
 js: js
 images: images
+# Config cdn
+cdn:
+  # set js cdn
+  # ${version} will be replaced by next-version e.g. 7.5.0
+  # ${file} be replaced by file name e.g. next-boot.js
+  #js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}

--- a/_config.yml
+++ b/_config.yml
@@ -1026,11 +1026,10 @@ vendors:
 
 # Assets
 css: css
-js: js
+# set js cdn
+# ${version} will be replaced by next-version e.g. 7.6.0
+# ${file} be replaced by file name e.g. next-boot.js
+# if you want to use jsdelivr, can config as follow (should use release version, not master)
+# js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}
+js: js/${file}
 images: images
-# Config cdn
-cdn:
-  # set js cdn
-  # ${version} will be replaced by next-version e.g. 7.5.0
-  # ${file} be replaced by file name e.g. next-boot.js
-  #js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -12,7 +12,19 @@ hexo.extend.helper.register('next_inject', function(point) {
 
 hexo.extend.helper.register('next_js', function(...urls) {
   const { js } = hexo.theme.config;
-  return urls.map(url => this.js(`${js}/${url}`)).join('');
+  let version = this.next_version;
+  let cdn = hexo.theme.config.cdn;
+  return urls
+    .map((url) => {
+      if (cdn && cdn.js) {
+        return cdn.js
+          .replace(/\$\{version\}/g, version)
+          .replace(/\$\{file\}/g, url);
+      }
+      return `${js}/${url}`;
+    })
+    .map(url => this.js(url))
+    .join('');
 });
 
 hexo.extend.helper.register('next_vendors', function(url) {

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -11,9 +11,8 @@ hexo.extend.helper.register('next_inject', function(point) {
 });
 
 hexo.extend.helper.register('next_js', function(...urls) {
-  const { js } = hexo.theme.config;
+  const { js, cdn } = hexo.theme.config;
   let version = this.next_version;
-  let cdn = hexo.theme.config.cdn;
   return urls
     .map((url) => {
       if (cdn && cdn.js) {

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -11,17 +11,12 @@ hexo.extend.helper.register('next_inject', function(point) {
 });
 
 hexo.extend.helper.register('next_js', function(...urls) {
-  const { js, cdn } = hexo.theme.config;
+  const { js } = hexo.theme.config;
   let version = this.next_version;
   return urls
-    .map((url) => {
-      if (cdn && cdn.js) {
-        return cdn.js
-          .replace(/\$\{version\}/g, version)
-          .replace(/\$\{file\}/g, url);
-      }
-      return `${js}/${url}`;
-    })
+    .map(url => js
+      .replace(/\$\{version\}/g, version)
+      .replace(/\$\{file\}/g, url))
     .map(url => this.js(url))
     .join('');
 });


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the new behavior?
Load js file from cdn
![image](https://user-images.githubusercontent.com/15902347/70767293-b3afca00-1d9b-11ea-9cb9-29ba0087859c.png)


### How to use?
In NexT `_config.yml`:
```yml
# If want to use jsdelivr, you can set it as follow
js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}
```

## Does this PR introduce a breaking change?
- [x] Yes.
- [ ] No.

```diff
- js: js
+ # set js cdn
+ # ${version} will be replaced by next-version e.g. 7.6.0
+ # ${file} be replaced by file name e.g. next-boot.js
+ # if you want to use jsdelivr, can config as follow (should use release version, not master)
+ # js: https://cdn.jsdelivr.net/gh/theme-next/hexo-theme-next@${version}/source/js/${file}
+ js: js/${file}
```