### PR TITLE
Fix conflict between animation of sub-menu icons and pjax

### DIFF
--- a/layout/_scripts/pjax.swig
+++ b/layout/_scripts/pjax.swig
@@ -48,6 +48,7 @@ window.addEventListener('pjax:success', () => {
   if (CONFIG.motion.enable) {
     NexT.motion.integrator
       .init()
+      .add(NexT.motion.middleWares.subMenu)
       .add(NexT.motion.middleWares.postList)
       .bootstrap();
   }

--- a/source/js/motion.js
+++ b/source/js/motion.js
@@ -112,6 +112,19 @@ NexT.motion.middleWares = {
     }
   },
 
+  subMenu: function(integrator) {
+    var subMenuItem = document.querySelectorAll('.sub-menu .menu-item');
+    if (subMenuItem.length > 0)
+    {
+      subMenuItem.forEach(
+        function(currentValue, currentIndex, listObj) {
+          currentValue.setAttribute('style', 'opacity: 1');
+        }
+      );
+    }
+    integrator.next();
+  },
+
   postList: function(integrator) {
 
     var postBlock = document.querySelectorAll('.post-block, .pagination, .comments');

--- a/source/js/motion.js
+++ b/source/js/motion.js
@@ -98,7 +98,6 @@ NexT.motion.middleWares = {
   },
 
   menu: function(integrator) {
-
     Velocity(document.querySelectorAll('.menu-item'), 'transition.slideDownIn', {
       display : null,
       duration: 200,
@@ -114,19 +113,13 @@ NexT.motion.middleWares = {
 
   subMenu: function(integrator) {
     var subMenuItem = document.querySelectorAll('.sub-menu .menu-item');
-    if (subMenuItem.length > 0)
-    {
-      subMenuItem.forEach(
-        function(currentValue, currentIndex, listObj) {
-          currentValue.setAttribute('style', 'opacity: 1');
-        }
-      );
+    if (subMenuItem.length > 0) {
+      subMenuItem.forEach(element => element.style.opacity = 1);
     }
     integrator.next();
   },
 
   postList: function(integrator) {
-
     var postBlock = document.querySelectorAll('.post-block, .pagination, .comments');
     var postBlockTransition = CONFIG.motion.transition.post_block;
     var postHeader = document.querySelectorAll('.post-header');
@@ -135,9 +128,8 @@ NexT.motion.middleWares = {
     var postBodyTransition = CONFIG.motion.transition.post_body;
     var collHeader = document.querySelectorAll('.collection-header');
     var collHeaderTransition = CONFIG.motion.transition.coll_header;
-    var hasPost = postBlock.length > 0;
 
-    if (hasPost) {
+    if (postBlock.length > 0) {
       var postMotionOptions = window.postMotionOptions || {
         stagger : 100,
         drag    : true,


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
cd path/to/theme-next
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.

5. Please check if your PR fulfills the following requirements.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

- Issue resolved:
When animation and pjax are both turned on, the sub-menu icons will become invisible after a pjax reload.
- Reason:
Sub-menu items have opacity of 0, as defined in css together with menu-item, which need to be animated to opacity 1 by velocity. However sub-menu is also in the part that pjax refreshes, and pjax script overlooks them, resulting in invisibility after pjax reload.
- A demo (with Pisces): https://foxb612.github.io/sub-menu-bug.gif


## What is the new behavior?
<!-- Description about this pull, in several words -->
Bug fixed.


## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
