### PR TITLE
Style back-to-top button to make sidebar more comfortable

### DIFF
--- a/source/css/_common/components/back-to-top-sidebar.styl
+++ b/source/css/_common/components/back-to-top-sidebar.styl
@@ -1,7 +1,7 @@
 .back-to-top {
   background: $b2t-sidebar-bg-color;
   font-size: $b2t-font-size;
-  margin: 8px - $sidebar-offset -10px -18px;
+  margin: 20px - $sidebar-offset -10px -20px;
   opacity: 0;
   text-align: center;
   the-transition();
@@ -15,7 +15,6 @@
   &.back-to-top-on {
     cursor: pointer;
     opacity: $b2t-opacity;
-    margin-top: 16px;
 
     &:hover {
       opacity: $b2t-opacity-hover;

--- a/source/css/_common/components/back-to-top-sidebar.styl
+++ b/source/css/_common/components/back-to-top-sidebar.styl
@@ -1,7 +1,7 @@
 .back-to-top {
   background: $b2t-sidebar-bg-color;
   font-size: $b2t-font-size;
-  margin: 20px - $sidebar-offset -10px -20px;
+  margin: 8px - $sidebar-offset -10px -18px;
   opacity: 0;
   text-align: center;
   the-transition();
@@ -15,6 +15,7 @@
   &.back-to-top-on {
     cursor: pointer;
     opacity: $b2t-opacity;
+    margin-top: 16px;
 
     &:hover {
       opacity: $b2t-opacity-hover;

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -120,10 +120,13 @@
   }
 }
 
-.back-to-top {
-  margin: 8px - $sidebar-offset -10px -18px;
+if (hexo-config('back2top.sidebar')) {
+  // Only when back2top.sidebar is true, apply the following styles
+  .back-to-top {
+    margin: 8px - $sidebar-offset -10px -18px;
 
-  &.back-to-top-on {
-    margin-top: 16px;
+    &.back-to-top-on {
+      margin-top: 16px;
+    }
   }
 }

--- a/source/css/_schemes/Pisces/_sidebar.styl
+++ b/source/css/_schemes/Pisces/_sidebar.styl
@@ -119,3 +119,11 @@
     }
   }
 }
+
+.back-to-top {
+  margin: 8px - $sidebar-offset -10px -18px;
+
+  &.back-to-top-on {
+    margin-top: 16px;
+  }
+}

--- a/source/js/utils.js
+++ b/source/js/utils.js
@@ -321,8 +321,8 @@ NexT.utils = {
     var sidebarOffset = CONFIG.sidebar.offset || 12;
     var sidebarb2tHeight = CONFIG.back2top.enable && CONFIG.back2top.sidebar ? document.querySelector('.back-to-top').offsetHeight : 0;
     var sidebarSchemePadding = (CONFIG.sidebar.padding * 2) + sidebarNavHeight + sidebarb2tHeight;
-    // Margin of sidebar b2t: 8px -10px -20px, brings a different of 12px.
-    if (CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') sidebarSchemePadding += (sidebarOffset * 2) - 12;
+    // Margin of sidebar b2t: -4px -10px -18px, brings a different of 22px.
+    if (CONFIG.scheme === 'Pisces' || CONFIG.scheme === 'Gemini') sidebarSchemePadding += (sidebarOffset * 2) - 22;
     // Initialize Sidebar & TOC Height.
     var sidebarWrapperHeight = document.body.offsetHeight - sidebarSchemePadding + 'px';
     document.querySelector('.site-overview-wrap').style.maxHeight = sidebarWrapperHeight;


### PR DESCRIPTION
Add margin-bottom: 10px to the root div, to make this part more comfortable.
Just a style patch.

<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
cd path/to/theme-next
npm install
npm run test
npm run test lint:stylus
```
And make sure that this PR does not cause more warning messages.

5. Please check if your PR fulfills the following requirements.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: 
Before adding an extra margin:
![image](https://user-images.githubusercontent.com/12205593/73816876-aacff780-4824-11ea-8cdf-7a82f2a6dda0.png)
Seems like the bottom of the links-of-blogroll is too narrow, may cause a weird feeling.

After applied this change:
![image](https://user-images.githubusercontent.com/12205593/73816759-63496b80-4824-11ea-930c-c4709c0f825f.png)


- Link to demo site with this changes: 
https://io.backrunner.top
You can see the part on the left.

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
