### PR TITLE
Fix config.search.path is null

### DIFF
--- a/scripts/helpers/next-config.js
+++ b/scripts/helpers/next-config.js
@@ -33,9 +33,11 @@ hexo.extend.helper.register('next_config', function() {
       labels   : theme.algolia_search.labels
     },
     localsearch: theme.local_search,
-    path       : config.search.path,
     motion     : theme.motion
   };
+  if (config.search) {
+    exportConfig.path = config.search.path;
+  }
   return `<script id="hexo-configurations">
     var NexT = window.NexT || {};
     var CONFIG = ${JSON.stringify(exportConfig)};


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [ ] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: https://github.com/theme-next/hexo-theme-next/issues/1373

## What is the new behavior?

There seems to be only `path` in the code. If the local search plugin is not installed, `config.search` does not exist.

### How to use?
In NexT `_config.yml`:
```yml

```

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
