### PR TITLE
Remove box-shadow of .sidebar when back2top.sidebar is true

### DIFF
--- a/source/css/_common/outline/sidebar/sidebar.styl
+++ b/source/css/_common/outline/sidebar/sidebar.styl
@@ -1,7 +1,9 @@
 .sidebar {
   background: $black-deep;
   bottom: 0;
-  box-shadow: inset 0 2px 6px black;
+  if (!hexo-config('back2top.sidebar')){
+    box-shadow: inset 0 2px 6px black;
+  }
   position: fixed;
   top: 0;
 


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build related changes.
- [ ] CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
![image](https://user-images.githubusercontent.com/12205593/74586822-6b748880-5026-11ea-8fa2-037cfc040c71.png)

The back2top button can't apply the shadow, it looks uncomfortable.

## What is the new behavior?
I removed the shadow of sidebar when back2top.sidebar is true.

- Screenshots with this changes: 
![image](https://user-images.githubusercontent.com/12205593/74586864-da51e180-5026-11ea-8aad-3e290e0553d9.png)

## Does this PR introduce a breaking change?
- [ ] Yes.
- [x] No.
