### PR TITLE
Add disqus-php-api integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -616,6 +616,18 @@ disqusjs:
   apikey: # Register new application from https://disqus.com/api/applications/
   shortname: # See: https://disqus.com/admin/settings/general/
 
+# Disqus PHP API
+# Demo: https://blog.fooleap.org/disqus-php-api.html
+# For more information: https://github.com/fooleap/disqus-php-api
+disqusapi:
+  enable: false
+  api: # Your server endpoint
+  forum: # Your disqus shortname
+  mode: 1
+  timeout: 3000
+  emojipreview: false
+  relatedtype: Related
+
 # Changyan
 changyan:
   enable: false

--- a/layout/_third-party/comments/disqusapi.swig
+++ b/layout/_third-party/comments/disqusapi.swig
@@ -1,0 +1,22 @@
+{%- if page.comments %}
+<link rel="stylesheet" href="{{ theme.disqusapi.api }}/dist/iDisqus.min.css">
+
+<script>
+NexT.utils.loadComments(document.querySelector('#disqusapi_thread'), () => {
+  NexT.utils.getScript('{{ theme.disqusapi.api }}/dist/iDisqus.min.js', () => {
+    window.dsqapi = new iDisqus('disqusapi_thread', {
+      forum         : '{{ theme.disqusapi.forum }}',
+      api           : '{{ theme.disqusapi.api }}/api/',
+      mode          : {{ theme.disqusapi.mode}},
+      timeout       : '{{ theme.disqusapi.timeout}}',  
+      url           : {{ page.permalink | json }},
+      identifier    : {{ page.path | json }},
+      title         : {{ page.title | json }},
+      init          : true,
+      emojiPreview  : {{ theme.disqusapi.emojipreview}},
+      relatedType   : '{{ theme.disqusapi.relatedtype}}'
+    });
+  }, window.DisqusAPI);
+});
+</script>
+{%- endif %}

--- a/scripts/filters/comment/disqusapi.js
+++ b/scripts/filters/comment/disqusapi.js
@@ -1,0 +1,22 @@
+/* global hexo */
+
+'use strict';
+
+const path = require('path');
+
+// Add comment
+hexo.extend.filter.register('theme_inject', injects => {
+  let theme = hexo.theme.config;
+  if (!theme.disqusapi.enable || !theme.disqusapi.api|| !theme.disqusapi.forum) return;
+
+  injects.comment.raw('disqusapi', `
+  <div class="comments">
+    <div id="disqusapi_thread">
+      <noscript>Please enable JavaScript to view the comments powered by Disqus.</noscript>
+    </div>
+  </div>
+  `, {}, {cache: true});
+
+  injects.bodyEnd.file('disqusapi', path.join(hexo.theme_dir, 'layout/_third-party/comments/disqusapi.swig'));
+
+});


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
cd path/to/theme-next
npm install
npm run test
npm run test lint:stylus
```

5. Please check if your PR fulfills the following requirements.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

**I have not added docs yet, but once the pull request is accepted, I will add docs ASAP.**

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
I added an integration of [disqus-php-api](https://github.com/fooleap/disqus-php-api), which is another Disqus proxy similar to disqusJS, **with some additional features** such as commenting, liking, sending pictures rather than only viewing comments as what disqusJS does.

## What is the new behavior?
<!-- Description about this pull, in several words -->
I added a `swig` file and `js` file and stored them in proper paths like what other comment systems did.

- Screenshots with these changes:
![QQ截图20200309210009](https://user-images.githubusercontent.com/13927774/76215134-05f07200-6249-11ea-84d0-752414ce90bc.png)
- Link to demo site with these changes: https://kaitohh.com/about/ **Make sure turn off any VPN or proxy before visiting this website.** Otherwise, you can only see the original Disqus.

### How to use?
In NexT `_config.yml`:
```yml
disqusapi:
  enable: true
  forum: 'kaitohh'
  api: 'https://disqus.kaitohh.com'
  mode: 2
  timeout: 2000
  emojipreview: true
  relatedtype: Related
```
The meaning of these options are available at [disqus-php-api](https://github.com/fooleap/disqus-php-api), including how to deploy the PHP server, so simply refer to this repo.