### PR TITLE
Fix dark styles of buttons

### DIFF
--- a/source/css/_colors.styl
+++ b/source/css/_colors.styl
@@ -10,6 +10,12 @@
   --table-row-odd-bg-color: $table-row-odd-bg-color;
   --table-row-hover-bg-color: $table-row-hover-bg-color;
   --menu-item-bg-color: $menu-item-bg-color;
+  --btn-default-bg: $btn-default-bg;
+  --btn-default-color: $btn-default-color;
+  --btn-default-border-color: $btn-default-border-color;
+  --btn-default-hover-bg: $btn-default-hover-bg;
+  --btn-default-hover-color: $btn-default-hover-color;
+  --btn-default-hover-border-color: $btn-default-hover-border-color;
 }
 
 if (hexo-config('darkmode')) {
@@ -26,6 +32,12 @@ if (hexo-config('darkmode')) {
       --table-row-odd-bg-color: $table-row-odd-bg-color-dark;
       --table-row-hover-bg-color: $table-row-hover-bg-color-dark;
       --menu-item-bg-color: $menu-item-bg-color-dark;
+      --btn-default-bg: $btn-default-bg-dark;
+      --btn-default-color: $btn-default-color-dark;
+      --btn-default-border-color: $btn-default-border-color-dark;
+      --btn-default-hover-bg: $btn-default-hover-bg-dark;
+      --btn-default-hover-color: $btn-default-hover-color-dark;
+      --btn-default-hover-border-color: $btn-default-hover-border-color-dark;
     }
 
     img {

--- a/source/css/_common/scaffolding/buttons.styl
+++ b/source/css/_common/scaffolding/buttons.styl
@@ -1,8 +1,8 @@
 .btn {
-  background: $btn-default-bg;
-  border: 2px solid $btn-default-border-color;
+  background: var(--btn-default-bg);
+  border: 2px solid var(--btn-default-border-color);
   border-radius: $btn-default-radius;
-  color: $btn-default-color;
+  color: var(--btn-default-color);
   display: inline-block;
   font-size: $font-size-small;
   line-height: 2;
@@ -12,9 +12,9 @@
   the-transition();
 
   &:hover {
-    background: $btn-default-hover-bg;
-    border-color: $btn-default-hover-border-color;
-    color: $btn-default-hover-color;
+    background: var(--btn-default-hover-bg);
+    border-color: var(--btn-default-hover-border-color);
+    color: var(--btn-default-hover-color);
   }
 
   + .btn {

--- a/source/css/_common/scaffolding/comments.styl
+++ b/source/css/_common/scaffolding/comments.styl
@@ -13,9 +13,9 @@
     margin: .1em .2em;
 
     &.active {
-      background: $btn-default-hover-bg;
-      border-color: $btn-default-hover-border-color;
-      color: $btn-default-hover-color;
+      background: var(--btn-default-hover-bg);
+      border-color: var(--btn-default-hover-border-color);
+      color: var(--btn-default-hover-color);
     }
   }
 }

--- a/source/css/_schemes/Mist/_posts-expand.styl
+++ b/source/css/_schemes/Mist/_posts-expand.styl
@@ -60,12 +60,12 @@
     // color: $grey-dim;
     background: none;
     border: 0;
-    border-bottom: 2px solid $btn-default-border-color;
+    border-bottom: 2px solid var(--btn-default-border-color);
     padding: 0;
     transition-property: border;
 
     &:hover {
-      border-bottom-color: $btn-default-hover-border-color;
+      border-bottom-color: var(--btn-default-hover-border-color);
     }
   }
 }

--- a/source/css/_schemes/Muse/_header.styl
+++ b/source/css/_schemes/Muse/_header.styl
@@ -21,5 +21,5 @@
 }
 
 .brand {
-  background: $btn-default-bg;
+  background: var(--btn-default-bg);
 }

--- a/source/css/_variables/Pisces.styl
+++ b/source/css/_variables/Pisces.styl
@@ -67,10 +67,10 @@ if (hexo-config('darkmode')) {
     :root{
       --btn-default-bg: #2e2e2e;
       --btn-default-color: var(--text-color);
-      --btn-default-border-color: #3e3e3e;
-      --btn-default-hover-bg: #4e4e4e;
-      --btn-default-hover-color: #4e4e4e;
-      --btn-default-hover-border-color: #4e4e4e;
+      --btn-default-border-color: $black-dim;
+      --btn-default-hover-bg: $black-light;
+      --btn-default-hover-color: var(--text-color);
+      --btn-default-hover-border-color: $black-light;
     }
   }
 }
@@ -79,7 +79,7 @@ $btn-default-bg                 = var(--btn-default-bg);
 $btn-default-color              = var(--btn-default-color);
 $btn-default-border-color       = var(--btn-default-border-color);
 $btn-default-hover-bg           = var(--btn-default-hover-bg);
-$btn-default-hover-color        = var(--btn-default-hover-colo);
+$btn-default-hover-color        = var(--btn-default-hover-color);
 $btn-default-hover-border-color = var(--btn-default-hover-border-color);
 
 // Back to top

--- a/source/css/_variables/Pisces.styl
+++ b/source/css/_variables/Pisces.styl
@@ -54,19 +54,33 @@ $site-state-item-border-color     = $gainsboro;
 // --------------------------------------------------
 
 // Button
-$btn-default-radius           = 2px;
-$btn-default-bg               = white;
-$btn-default-color            = $text-color;
-$btn-default-border-color     = $text-color;
-$btn-default-hover-bg         = $black-deep;
-$btn-default-hover-color      = white;
-if (hexo-config('darkmode')) {
-  $btn-default-bg                 = #2e2e2e;
-  $btn-default-hover-bg           = #4e4e4e;
-  $btn-default-color              = var(--text-color);
-  $btn-default-border-color       = #3e3e3e;
-  $btn-default-hover-border-color = #4e4e4e;
+:root {
+  --btn-default-bg: white;
+  --btn-default-color: $text-color;
+  --btn-default-border-color: $text-color;
+  --btn-default-hover-bg: $black-deep;
+  --btn-default-hover-color: white;
+  --btn-default-hover-border-color: $black-deep;
 }
+if (hexo-config('darkmode')) {
+  @media (prefers-color-scheme: dark) {
+    :root{
+      --btn-default-bg: #2e2e2e;
+      --btn-default-color: var(--text-color);
+      --btn-default-border-color: #3e3e3e;
+      --btn-default-hover-bg: #4e4e4e;
+      --btn-default-hover-color: #4e4e4e;
+      --btn-default-hover-border-color: #4e4e4e;
+    }
+  }
+}
+$btn-default-radius             = 2px;
+$btn-default-bg                 = var(--btn-default-bg);
+$btn-default-color              = var(--btn-default-color);
+$btn-default-border-color       = var(--btn-default-border-color);
+$btn-default-hover-bg           = var(--btn-default-hover-bg);
+$btn-default-hover-color        = var(--btn-default-hover-colo);
+$btn-default-hover-border-color = var(--btn-default-hover-border-color);
 
 // Back to top
 $b2t-opacity                  = .6;

--- a/source/css/_variables/Pisces.styl
+++ b/source/css/_variables/Pisces.styl
@@ -54,33 +54,12 @@ $site-state-item-border-color     = $gainsboro;
 // --------------------------------------------------
 
 // Button
-:root {
-  --btn-default-bg: white;
-  --btn-default-color: $text-color;
-  --btn-default-border-color: $text-color;
-  --btn-default-hover-bg: $black-deep;
-  --btn-default-hover-color: white;
-  --btn-default-hover-border-color: $black-deep;
-}
-if (hexo-config('darkmode')) {
-  @media (prefers-color-scheme: dark) {
-    :root{
-      --btn-default-bg: #2e2e2e;
-      --btn-default-color: var(--text-color);
-      --btn-default-border-color: $black-dim;
-      --btn-default-hover-bg: $black-light;
-      --btn-default-hover-color: var(--text-color);
-      --btn-default-hover-border-color: $black-light;
-    }
-  }
-}
-$btn-default-radius             = 2px;
-$btn-default-bg                 = var(--btn-default-bg);
-$btn-default-color              = var(--btn-default-color);
-$btn-default-border-color       = var(--btn-default-border-color);
-$btn-default-hover-bg           = var(--btn-default-hover-bg);
-$btn-default-hover-color        = var(--btn-default-hover-color);
-$btn-default-hover-border-color = var(--btn-default-hover-border-color);
+$btn-default-radius           = 2px;
+$btn-default-bg               = white;
+$btn-default-color            = $text-color;
+$btn-default-border-color     = $text-color;
+$btn-default-hover-bg         = $black-deep;
+$btn-default-hover-color      = white;
 
 // Back to top
 $b2t-opacity                  = .6;

--- a/source/css/_variables/Pisces.styl
+++ b/source/css/_variables/Pisces.styl
@@ -60,6 +60,13 @@ $btn-default-color            = $text-color;
 $btn-default-border-color     = $text-color;
 $btn-default-hover-bg         = $black-deep;
 $btn-default-hover-color      = white;
+if (hexo-config('darkmode')) {
+  $btn-default-bg                 = #2e2e2e;
+  $btn-default-hover-bg           = #4e4e4e;
+  $btn-default-color              = var(--text-color);
+  $btn-default-border-color       = #3e3e3e;
+  $btn-default-hover-border-color = #4e4e4e;
+}
 
 // Back to top
 $b2t-opacity                  = .6;

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -137,13 +137,19 @@ $code-background                = $gainsboro;
 
 // Buttons
 // --------------------------------------------------
-$btn-default-radius             = 0;
-$btn-default-bg                 = $black-deep;
-$btn-default-color              = white;
-$btn-default-border-color       = $black-deep;
-$btn-default-hover-bg           = white;
-$btn-default-hover-color        = $black-deep;
-$btn-default-hover-border-color = $black-deep;
+$btn-default-radius                    = 0;
+$btn-default-bg                        = $black-deep;
+$btn-default-bg-dark                   = $black-deep;
+$btn-default-color                     = white;
+$btn-default-color-dark                = $text-color-dark;
+$btn-default-border-color              = $black-deep;
+$btn-default-border-color-dark         = $black-dim;
+$btn-default-hover-bg                  = white;
+$btn-default-hover-bg-dark             = $black-light;
+$btn-default-hover-color               = $black-deep;
+$btn-default-hover-color-dark          = $text-color-dark;
+$btn-default-hover-border-color        = $black-deep;
+$btn-default-hover-border-color-dark   = $black-light;
 
 
 // Pagination


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.

4. We use ESLint and Stylint for identifying and reporting on patterns in JavaScript and Stylus. Please execute the following commands:
```sh
cd path/to/theme-next
npm install
npm run test
npm run test lint:stylus
```

5. Please check if your PR fulfills the following requirements.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation content changes.
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->

In current released version, when dark mode and scheme Pisces or Gemini  is enabled, the button in post-expand is still using the default styles:

![image](https://user-images.githubusercontent.com/12205593/76493215-17b25f00-646d-11ea-8983-423160c7f1e4.png)

I made a set of dark styles for these buttons:

![image](https://user-images.githubusercontent.com/12205593/76495037-0cf9c900-6471-11ea-8cea-a84fa3f1a808.png)

hover:
![image](https://user-images.githubusercontent.com/12205593/76495053-12efaa00-6471-11ea-8962-69d4bba96a3c.png)

- Link to demo site with this changes: N/A
