### PR TITLE
Remove `seo` option in `_config.yml`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -461,9 +461,6 @@ font:
 # Disable Baidu transformation on mobile devices.
 disable_baidu_transformation: false
 
-# Change headers hierarchy on site-subtitle (will be main site description) and on all post / page titles for better SEO-optimization.
-seo: false
-
 # If true, site-subtitle will be added to index page.
 # Remember to set up your site-subtitle in Hexo `_config.yml` (e.g. subtitle: Subtitle)
 index_with_subtitle: false

--- a/layout/_macro/post-collapse.swig
+++ b/layout/_macro/post-collapse.swig
@@ -7,7 +7,7 @@
   {%- if year !== current_year %}
     {%- set current_year = year %}
     <div class="collection-year">
-      <{%- if theme.seo %}h2{% else %}h1{%- endif %} class="collection-header">{{ current_year }}</{%- if theme.seo %}h2{% else %}h1{%- endif %}>
+      <span class="collection-header">{{ current_year }}</span>
     </div>
   {%- endif %}
 
@@ -22,7 +22,7 @@
         </time>
       </div>
 
-      <{%- if theme.seo %}h3{% else %}h2{%- endif %} class="post-title">
+      <div class="post-title">
         {%- if post.link %}{# Link posts #}
           {%- set postTitleIcon = '<i class="fa fa-external-link"></i>' %}
           {%- set postText = post.title or post.link %}
@@ -32,7 +32,7 @@
             <span itemprop="name">{{ post.title or __('post.untitled') }}</span>
           </a>
         {%- endif %}
-      </{%- if theme.seo %}h3{% else %}h2{%- endif %}>
+      </div>
 
     </header>
   </article>

--- a/layout/_macro/post.swig
+++ b/layout/_macro/post.swig
@@ -16,7 +16,7 @@
 
     {%- if post.header !== false %}
       <header class="post-header">
-        <{%- if theme.seo %}h2{% else %}h1{%- endif %} class="post-title{%- if post.direction and post.direction.toLowerCase() === 'rtl' %} rtl{%- endif %}" itemprop="name headline">
+        <{%- if is_index %}h2{% else %}h1{%- endif %} class="post-title{%- if post.direction and post.direction.toLowerCase() === 'rtl' %} rtl{%- endif %}" itemprop="name headline">
           {# Link posts #}
           {%- if post.link %}
             {%- if post.sticky > 0 %}
@@ -38,7 +38,7 @@
             {{- post.title }}
             {{- post_edit(post.source) }}
           {%- endif %}
-        </{%- if theme.seo %}h2{% else %}h1{%- endif %}>
+        </{%- if is_index %}h2{% else %}h1{%- endif %}>
 
         <div class="post-meta">
 

--- a/layout/_partials/header/brand.swig
+++ b/layout/_partials/header/brand.swig
@@ -16,19 +16,13 @@
       </div>
     {%- endif %}
 
-    <div>
-      <a href="{{ config.root }}" class="brand" rel="start">
-        <span class="logo-line-before"><i></i></span>
-        <span class="site-title">{{ title }}</span>
-        <span class="logo-line-after"><i></i></span>
-      </a>
-    </div>
+    <a href="{{ config.root }}" class="brand" rel="start">
+      <span class="logo-line-before"><i></i></span>
+      <span class="site-title">{{ title }}</span>
+      <span class="logo-line-after"><i></i></span>
+    </a>
     {%- if subtitle %}
-      {%- if theme.seo %}
-        <h1 class="site-subtitle" itemprop="description">{{ subtitle }}</h1>
-      {% else %}
-        <p class="site-subtitle">{{ subtitle }}</p>
-      {%- endif %}
+      <p class="site-subtitle" itemprop="description">{{ subtitle }}</p>
     {%- endif %}
     {%- if theme.custom_logo and (theme.scheme === 'Gemini' or theme.scheme === 'Pisces') %}
       <a>

--- a/layout/_partials/header/brand.swig
+++ b/layout/_partials/header/brand.swig
@@ -18,7 +18,7 @@
 
     <a href="{{ config.root }}" class="brand" rel="start">
       <span class="logo-line-before"><i></i></span>
-      <span class="site-title">{{ title }}</span>
+      <h1 class="site-title">{{ title }}</h1>
       <span class="logo-line-after"><i></i></span>
     </a>
     {%- if subtitle %}

--- a/layout/_partials/header/index.swig
+++ b/layout/_partials/header/index.swig
@@ -1,13 +1,7 @@
 {{ partial('_partials/header/brand.swig', {}, {cache: theme.cache.enable}) }}
 
-<nav class="site-nav">
-  {{ partial('_partials/header/menu.swig', {}, {cache: theme.cache.enable}) }}
-</nav>
+{{ partial('_partials/header/menu.swig', {}, {cache: theme.cache.enable}) }}
 
-{%- if theme.algolia_search.enable or theme.local_search.enable %}
-  <div class="site-search">
-    {{ partial('_partials/search/index.swig', {}, {cache: theme.cache.enable}) }}
-  </div>
-{%- endif %}
+{{ partial('_partials/search/index.swig', {}, {cache: theme.cache.enable}) }}
 
 {{- next_inject('header') }}

--- a/layout/_partials/header/menu.swig
+++ b/layout/_partials/header/menu.swig
@@ -1,5 +1,6 @@
 {% import 'menu-item.swig' as menu_item with context %}
 
+<nav class="site-nav">
 {%- if theme.menu %}
   <ul id="menu" class="menu">
     {%- for name, path in theme.menu %}
@@ -30,3 +31,4 @@
     {%- endif %}
   </ul>
 {%- endif %}
+</nav>

--- a/layout/_partials/page/page-header.swig
+++ b/layout/_partials/page/page-header.swig
@@ -1,9 +1,9 @@
 <header class="post-header">
 
-<{%- if theme.seo %}h2{% else %}h1{%- endif %} class="post-title" itemprop="name headline">
+<h1 class="post-title" itemprop="name headline">
   {{- page.title }}
   {{- post_edit(page.source) }}
-</{%- if theme.seo %}h2{% else %}h1{%- endif %}>
+</h1>
 
 <div class="post-meta">
   {%- if page.description %}

--- a/layout/_partials/search/index.swig
+++ b/layout/_partials/search/index.swig
@@ -1,9 +1,11 @@
-<div class="search-pop-overlay">
-  <div class="popup search-popup">
-    {%- if theme.algolia_search.enable %}
-      {% include 'algolia-search.swig' %}
-    {% elif theme.local_search.enable %}
-      {% include 'localsearch.swig' %}
-    {%- endif %}
+{%- if theme.algolia_search.enable or theme.local_search.enable %}
+  <div class="search-pop-overlay">
+    <div class="popup search-popup">
+      {%- if theme.algolia_search.enable %}
+        {% include 'algolia-search.swig' %}
+      {% elif theme.local_search.enable %}
+        {% include 'localsearch.swig' %}
+      {%- endif %}
+    </div>
   </div>
-</div>
+{%- endif %}

--- a/layout/category.swig
+++ b/layout/category.swig
@@ -12,10 +12,10 @@
   <div class="post-block">
     <div class="posts-collapse">
       <div class="collection-title">
-        <{%- if theme.seo %}h2{% else %}h1{%- endif %} class="collection-header">
+        <h2 class="collection-header">
           {{- page.category }}
           <small>{{ __('title.category') }}</small>
-        </{%- if theme.seo %}h2{% else %}h1{%- endif %}>
+        </h2>
       </div>
 
       {{ post_template.render(page.posts) }}

--- a/layout/tag.swig
+++ b/layout/tag.swig
@@ -12,10 +12,10 @@
   <div class="post-block">
     <div class="posts-collapse">
       <div class="collection-title">
-        <{%- if theme.seo %}h2{% else %}h1{%- endif %} class="collection-header">
+        <h2 class="collection-header">
           {{- page.tag }}
           <small>{{ __('title.tag') }}</small>
-        </{%- if theme.seo %}h2{% else %}h1{%- endif %}>
+        </h2>
       </div>
 
       {{ post_template.render(page.posts) }}

--- a/source/css/_common/components/post/post-collapse.styl
+++ b/source/css/_common/components/post/post-collapse.styl
@@ -28,6 +28,8 @@
   }
 
   .collection-year {
+    font-size: $font-size-largest;
+    font-weight: bold;
     margin: 60px 0;
     position: relative;
 
@@ -46,7 +48,6 @@
   }
 
   .collection-header {
-    display: inline-block;
     margin: 0 0 0 20px;
 
     small {
@@ -95,8 +96,6 @@
 
   .post-title {
     display: inline;
-    font-size: $font-size-medium;
-    font-weight: normal;
 
     a, span.exturl {
       border-bottom: none;

--- a/source/css/_common/components/post/post-header.styl
+++ b/source/css/_common/components/post/post-header.styl
@@ -3,6 +3,7 @@
 }
 
 .posts-expand .post-title {
+  font-size: $font-size-largest;
   font-weight: normal;
   margin: initial;
   text-align: center;

--- a/source/css/_common/components/third-party/search.styl
+++ b/source/css/_common/components/third-party/search.styl
@@ -51,7 +51,7 @@
   }
 }
 
-.site-search input.search-input {
+.search-popup input.search-input {
   background: transparent;
   border: 0;
   outline: 0;

--- a/source/css/_common/components/third-party/search.styl
+++ b/source/css/_common/components/third-party/search.styl
@@ -51,7 +51,7 @@
   }
 }
 
-.search-popup input.search-input {
+.site-search input.search-input {
   background: transparent;
   border: 0;
   outline: 0;

--- a/source/css/_common/outline/header/site-meta.styl
+++ b/source/css/_common/outline/header/site-meta.styl
@@ -21,12 +21,10 @@
 }
 
 .site-title {
-  display: inline-block;
   font-family: $font-family-logo;
   font-size: $font-size-title;
   font-weight: normal;
-  line-height: 1.5;
-  vertical-align: top;
+  margin: 0;
 }
 
 .site-subtitle {

--- a/source/css/_variables/base.styl
+++ b/source/css/_variables/base.styl
@@ -94,7 +94,7 @@ $font-size-small          = .875em;
 $font-size-medium         = 1em;
 $font-size-large          = 1.125em;
 $font-size-larger         = 1.25em;
-$font-size-largest        = 1.375em;
+$font-size-largest        = 1.5em;
 
 
 // Headings font size
@@ -192,7 +192,7 @@ $brand-hover-color              = white;
 $brand-color-dark               = white;
 $brand-hover-color-dark         = white;
 
-$font-size-title                = (hexo-config('font.enable') and hexo-config('font.title.size') is a 'unit') ? unit(hexo-config('font.title.size'), em) : $font-size-largest;
+$font-size-title                = (hexo-config('font.enable') and hexo-config('font.title.size') is a 'unit') ? unit(hexo-config('font.title.size'), em) : 1.375em;
 $font-size-subtitle             = $font-size-smaller;
 $subtitle-color                 = $grey-dark;
 $site-subtitle-color            = $grey-dark;


### PR DESCRIPTION
References:
> Multiple H1 Headings: How to Handle Them for SEO & Accessibility?
> https://www.youtube.com/watch?v=zyqJJXWk0gk
> https://www.youtube.com/watch?v=WsgrSxCmMbM

According to google, multiple h1 on the page will not negatively affect seo.
Tests have shown that if all pages are required to have one and only one h1, then `brand.swig` cannot be cached, which results in an ~8% slowdown in `hexo g`.

https://github.com/theme-next/hexo-theme-next/blob/aee74badd046d7d70b661a8a70110016f62858cb/layout/_partials/header/brand.swig#L22
```
{%- if is_post() or is_page() %}span{% else %}h1{%- endif %}
```