### PR TITLE
Add a minimalist comment -- minivaline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -659,6 +659,7 @@ minivaline:
   # Available values: en | es-ES | fr | ru | zh-CN | zh-TW
   language:
 
+
 # Gitalk
 # For more information: https://gitalk.github.io, https://github.com/gitalk/gitalk
 gitalk:

--- a/_config.yml
+++ b/_config.yml
@@ -640,6 +640,25 @@ valine:
 # You can get your uid from https://livere.com/insight/myCode (General web site)
 livere_uid: # <your_uid>
 
+# MiniValine
+# © 2017 云淡风轻 © 2018 Modified by Deserts © 2020 Modified by MHuiG
+# You can get your appid and appkey from https://leancloud.cn
+# For more information: https://github.com/MHuiG/MiniValine, https://deserts.io/diy-a-comment-system/
+# Valine-Admin information: https://deserts.io/valine-admin-document/
+minivaline:
+  enable: false
+  appid: # Your leancloud application appid
+  appkey: # Your leancloud application appkey
+  placeholder: Write a Comment # Comment box placeholder
+  maxNest: 3 # Nest size
+  pageSize: 6 # Pagination size
+  adminEmailMd5: # The MD5 of Admin Email to show Admin Flag.
+  math: true # Support Init MathJax.
+  # MiniValine's display language depends on user's browser or system environment
+  # If you want everyone visiting your site to see a uniform language, you can set a force language value
+  # Available values: en | es-ES | fr | ru | zh-CN | zh-TW
+  language:
+
 # Gitalk
 # For more information: https://gitalk.github.io, https://github.com/gitalk/gitalk
 gitalk:
@@ -952,6 +971,11 @@ vendors:
   # valine: //cdn.jsdelivr.net/npm/valine@1/dist/Valine.min.js
   # valine: //cdnjs.cloudflare.com/ajax/libs/valine/1.3.10/Valine.min.js
   valine:
+
+  # MiniValine
+  # minivaline: //cdn.jsdelivr.net/gh/MHuiG/MiniValine/dist/MiniValine.min.js
+  # minivaline: //unpkg.com/minivaline/dist/MiniValine.min.js
+  minivaline:
 
   # Gitalk
   # gitalk_js: //cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js

--- a/layout/_third-party/comments/minivaline.swig
+++ b/layout/_third-party/comments/minivaline.swig
@@ -1,8 +1,8 @@
-{%- set valine_uri = theme.vendors.minivaline or '//unpkg.com/minivaline/dist/MiniValine.min.js' %}
+{%- set minivaline_uri = theme.vendors.minivaline or '//unpkg.com/minivaline/dist/MiniValine.min.js' %}
 
 <script>
 NexT.utils.loadComments(document.querySelector('#minivaline-comments'), () => {
-  NexT.utils.getScript('{{ valine_uri }}', () => {
+  NexT.utils.getScript('{{ minivaline_uri }}', () => {
     new MiniValine({
       el: '#minivaline-comments',
       appId: '{{ theme.minivaline.appid }}',

--- a/layout/_third-party/comments/minivaline.swig
+++ b/layout/_third-party/comments/minivaline.swig
@@ -1,0 +1,24 @@
+{%- set valine_uri = theme.vendors.minivaline or '//unpkg.com/minivaline/dist/MiniValine.min.js' %}
+
+<script>
+NexT.utils.loadComments(document.querySelector('#minivaline-comments'), () => {
+  NexT.utils.getScript('{{ valine_uri }}', () => {
+    new MiniValine({
+      el: '#minivaline-comments',
+      appId: '{{ theme.minivaline.appid }}',
+      appKey: '{{ theme.minivaline.appkey }}',
+      placeholder: '{{ theme.minivaline.placeholder }}',
+      {%- if theme.minivaline.language == '' %}
+        lang: window.navigator.language || window.navigator.userLanguage,
+      {% else %}
+        lang: '{{ theme.minivaline.language }}',
+      {%- endif %}
+      adminEmailMd5: '{{ theme.minivaline.adminEmailMd5 }}',
+      math: {{ theme.minivaline.math }} || false,
+      maxNest: {{ theme.minivaline.maxNest }} || 3,
+      pageSize: {{ theme.minivaline.pageSize }} || 6，
+	  pathname: '/{{ page.path }}'
+    });
+  }, window.MiniValine);
+});
+</script>

--- a/scripts/filters/comment/minivaline.js
+++ b/scripts/filters/comment/minivaline.js
@@ -1,0 +1,17 @@
+/* global hexo */
+
+'use strict';
+
+const path = require('path');
+const { iconText } = require('./common');
+
+// Add comment
+hexo.extend.filter.register('theme_inject', injects => {
+  let theme = hexo.theme.config;
+  if (!theme.minivaline.enable || !theme.minivaline.appid || !theme.minivaline.appkey) return;
+
+  injects.comment.raw('minivaline', '<div class="comments" id="minivaline-comments"></div>', {}, {cache: true});
+
+  injects.bodyEnd.file('minivaline', path.join(hexo.theme_dir, 'layout/_third-party/comments/minivaline.swig'));
+
+});


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: N/A
add a minimalist comment -- minivaline
## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A
[demo site](https://mhuig.github.io/guestbook/)
### How to use?
In NexT `_config.yml`:
```yml
minivaline:
  enable: false
  appid:  # Your leancloud application appid
  appkey:  # Your leancloud application appkey
  placeholder: Write a Comment O(∩_∩)O~~ # Comment box placeholder
  maxNest: 3 # Nest size
  pageSize: 6 # Pagination size
  adminEmailMd5: # The MD5 of Admin Email to show Admin Flag.
  math: true # Support MathJax.
  # MiniValine's display language depends on user's browser or system environment
  # If you want everyone visiting your site to see a uniform language, you can set a force language value
  # Available values: en | es-ES | fr | ru | zh-CN | zh-TW
  language:
```
