### PR TITLE
Fix: bind event DOMContentLoaded on document insteadof window

### DIFF
--- a/source/js/algolia-search.js
+++ b/source/js/algolia-search.js
@@ -1,6 +1,6 @@
 /* global instantsearch, algoliasearch, CONFIG */
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
   const algoliaSettings = CONFIG.algolia;
   const { indexName, appID, apiKey } = algoliaSettings;
 

--- a/source/js/bookmark.js
+++ b/source/js/bookmark.js
@@ -1,6 +1,6 @@
 /* global CONFIG */
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
   'use strict';
 
   var doSaveScroll = () => {

--- a/source/js/local-search.js
+++ b/source/js/local-search.js
@@ -1,6 +1,6 @@
 /* global CONFIG */
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
   // Popup Window
   let isfetched = false;
   let datas;

--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -107,7 +107,7 @@ NexT.boot.motion = function() {
   NexT.utils.updateSidebarPosition();
 };
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
   NexT.boot.registerEvents();
   NexT.boot.refresh();
   NexT.boot.motion();

--- a/source/js/schemes/muse.js
+++ b/source/js/schemes/muse.js
@@ -1,6 +1,6 @@
 /* global NexT, CONFIG, Velocity */
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
 
   var isRight = CONFIG.sidebar.position === 'right';
   var SIDEBAR_WIDTH = CONFIG.sidebar.width || 320;

--- a/source/js/schemes/pisces.js
+++ b/source/js/schemes/pisces.js
@@ -80,7 +80,7 @@ NexT.utils.getAffixParam = function() {
   };
 };
 
-window.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', () => {
 
   Affix.init(document.querySelector('.sidebar-inner'), NexT.utils.getAffixParam());
 });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
From the [doc](https://developer.mozilla.org/zh-CN/docs/Web/Events/DOMContentLoaded) we know that the target of  event "DOMContentLoaded" should be document not the window. In some cases such as rocket loader of cloudflare, the events bind on the window will never be fired.
Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml

```
