### PR TITLE
Add valine template , update cdn url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -613,8 +613,6 @@ valine:
   enable: false
   appid: # Your leancloud application appid
   appkey: # Your leancloud application appkey
-  notify: false # Mail notifier
-  verify: false # Verification code
   placeholder: Just go go # Comment box placeholder
   avatar: mm # Gravatar style
   guest_info: nick,mail,link # Custom comment header

--- a/_config.yml
+++ b/_config.yml
@@ -622,7 +622,7 @@ valine:
   comment_count: true # If false, comment count will only be displayed in post page, not in home page
   recordIP: false # Whether to record the commenter IP
   serverURLs: # When the custom domain name is enabled, fill it in here (it will be detected automatically by default, no need to fill in)
-  enableQQ: true # Whether to enable the Nickname box to automatically get QQ Nickname and QQ Avatar
+  enableQQ: false # Whether to enable the Nickname box to automatically get QQ Nickname and QQ Avatar
   # See: https://valine.js.org/emoji.html
   emojiCDN: 
   emojiMaps: 

--- a/_config.yml
+++ b/_config.yml
@@ -624,6 +624,10 @@ valine:
   comment_count: true # If false, comment count will only be displayed in post page, not in home page
   recordIP: false # Whether to record the commenter IP
   serverURLs: # When the custom domain name is enabled, fill it in here (it will be detected automatically by default, no need to fill in)
+  enableQQ: true # Whether to enable the Nickname box to automatically get QQ Nickname and QQ Avatar
+  # See: https://valine.js.org/emoji.html
+  emojiCDN: 
+  emojiMaps: 
   #post_meta_order: 0
 
 # LiveRe comments system
@@ -941,7 +945,7 @@ vendors:
 
   # Valine
   # valine: //cdn.jsdelivr.net/npm/valine@1/dist/Valine.min.js
-  # valine: //cdnjs.cloudflare.com/ajax/libs/valine/1.3.10/Valine.min.js
+  # valine: //cdnjs.cloudflare.com/ajax/libs/valine/1.4.14/Valine.min.js
   valine:
 
   # Gitalk

--- a/layout/_third-party/comments/valine.swig
+++ b/layout/_third-party/comments/valine.swig
@@ -25,9 +25,9 @@ NexT.utils.loadComments(document.querySelector('#valine-comments'), () => {
       path       : location.pathname,
       recordIP   : {{ theme.valine.recordIP }},
       serverURLs : '{{ theme.valine.serverURLs }}',
+      enableQQ   : {{ theme.valine.enableQQ }},
       emojiCDN   : '{{ theme.valine.emojiCDN }}', 
-      emojiMaps  : maps,
-      enableQQ   : {{ theme.valine.enableQQ }}
+      emojiMaps  : maps
     });
   }, window.Valine);
 });

--- a/layout/_third-party/comments/valine.swig
+++ b/layout/_third-party/comments/valine.swig
@@ -8,6 +8,10 @@ NexT.utils.loadComments(document.querySelector('#valine-comments'), () => {
     guest = guest.split(',').filter(item => {
       return GUEST.includes(item);
     });
+    var maps = { {{ theme.valine.emojiMaps }} }
+    if (maps = {  }){
+      maps = ''
+    }
     new Valine({
       el         : '#valine-comments',
       verify     : {{ theme.valine.verify }},
@@ -22,7 +26,10 @@ NexT.utils.loadComments(document.querySelector('#valine-comments'), () => {
       lang       : '{{ theme.valine.language }}' || 'zh-cn',
       path       : location.pathname,
       recordIP   : {{ theme.valine.recordIP }},
-      serverURLs : '{{ theme.valine.serverURLs }}'
+      serverURLs : '{{ theme.valine.serverURLs }}',
+      emojiCDN   : '{{ theme.valine.emojiCDN }}', 
+      emojiMaps  : maps,
+      enableQQ   : {{ theme.valine.enableQQ }}
     });
   }, window.Valine);
 });

--- a/layout/_third-party/comments/valine.swig
+++ b/layout/_third-party/comments/valine.swig
@@ -8,9 +8,9 @@ NexT.utils.loadComments(document.querySelector('#valine-comments'), () => {
     guest = guest.split(',').filter(item => {
       return GUEST.includes(item);
     });
-    var maps = { {{ theme.valine.emojiMaps }} }
-    if (maps = {  }){
-      maps = ''
+    var maps = { {{ theme.valine.emojiMaps }} };
+    if (JSON.stringify(maps) === '{}') {
+      maps = null
     }
     new Valine({
       el         : '#valine-comments',

--- a/layout/_third-party/comments/valine.swig
+++ b/layout/_third-party/comments/valine.swig
@@ -14,8 +14,6 @@ NexT.utils.loadComments(document.querySelector('#valine-comments'), () => {
     }
     new Valine({
       el         : '#valine-comments',
-      verify     : {{ theme.valine.verify }},
-      notify     : {{ theme.valine.notify }},
       appId      : '{{ theme.valine.appid }}',
       appKey     : '{{ theme.valine.appkey }}',
       placeholder: {{ theme.valine.placeholder | json }},


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #1475

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
valine:
  enableQQ: true # Whether to enable the Nickname box to automatically get QQ Nickname and QQ Avatar
  # See: https://valine.js.org/emoji.html
  emojiCDN: 
  emojiMaps: 
```
