### PR TITLE
 Add Valine support KAtex

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -899,7 +899,8 @@ vendors:
   # katex: //cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css
   # copy_tex_js: //cdn.jsdelivr.net/npm/katex@0/dist/contrib/copy-tex.min.js
   # copy_tex_css: //cdn.jsdelivr.net/npm/katex@0/dist/contrib/copy-tex.min.css
-  katex:
+  katex_css:
+  Katex_js:
   copy_tex_js:
   copy_tex_css:
 

--- a/layout/_partials/head/head.swig
+++ b/layout/_partials/head/head.swig
@@ -58,4 +58,11 @@
   <script src="{{ pace_js_uri }}"></script>
 {%- endif %}
 
+{%- if not theme.math.per_page or is_index_has_math or page.mathjax %}
+  {%- if theme.math.katex %}
+    {%- set autorender_js_uri = next_vendors('//cdn.jsdelivr.net/npm/katex@0.11.1/dist/contrib/auto-render.min.js') %}
+    <script defer src="{{ autorender_js_uri }}" onload="renderMathInElement(document.body);"></script>
+  {%- endif %}
+{%- endif %}
+
 {{ next_config() }}

--- a/layout/_third-party/math/katex.swig
+++ b/layout/_third-party/math/katex.swig
@@ -1,5 +1,7 @@
-{%- set katex_uri = theme.vendors.katex or '//cdn.jsdelivr.net/npm/katex@0/dist/katex.min.css' %}
-<link rel="stylesheet" href="{{ katex_uri }}">
+{%- set katex_css_uri = theme.vendors.katex_css or next_vendors('//cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css') %}
+{%- set katex_js_uri = theme.vendors.katex_js or next_vendors('//cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.js') %}
+<link rel="stylesheet" href="{{ katex_css_uri }}">
+<script src="{{ katex_js_uri }}"></script>
 {%- if theme.math.katex.copy_tex %}
   {%- set copy_tex_js_uri = theme.vendors.copy_tex_js or '//cdn.jsdelivr.net/npm/katex@0/dist/contrib/copy-tex.min.js' %}
   {%- set copy_tex_css_uri = theme.vendors.copy_tex_css or '//cdn.jsdelivr.net/npm/katex@0/dist/contrib/copy-tex.min.css' %}


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: #1486 

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: 
![QQ截图20200506121417](https://user-images.githubusercontent.com/30137019/81139759-85749600-8f99-11ea-8b3e-c8970591c4d3.jpg)

- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml

```
