### PR TITLE
Wrap `gongan_icon_url` with `url_for`

### DIFF
--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -2,7 +2,7 @@
   <div class="beian">
     {{- next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}
     {%- if theme.footer.beian.gongan_icon_url %}
-      <img src="{{ theme.footer.beian.gongan_icon_url }}" style="display: inline-block;">
+      <img src="{{ url_for(theme.footer.beian.gongan_icon_url) }}" style="display: inline-block;">
     {%- endif %}
     {%- if theme.footer.beian.gongan_id and theme.footer.beian.gongan_num %}
       {{- next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.beian.gongan_id, theme.footer.beian.gongan_num + ' ') }}


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
The path to `gongan_icon_url` may be incorrect when it is set to a relative path like `gongan.png` in _config.yml.

For example, assume `gongan_icon_url` is `gongan.png` and current page url is `localhost:4000/page/3/`, the exact source of the generated img element is `localhost:4000/page/3/gongan.png`, rather than `localhost:4000/gongan.png`.

## What is the new behavior?

It should be wrapped with `url_for` like [this](https://github.com/theme-next/hexo-theme-next/blob/a7a948a08f48dbe48879e277703d75706aec18e5/layout/_partials/sidebar/site-overview.swig#L4).

### How to use?
In NexT `_config.yml`:
```yml
footer:
  beian:
    gongan_icon_url: beian.png
```
