### PR TITLE
Bug Fix:  about footer.swig

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -65,6 +65,7 @@ footer:
 
   # If not defined, `author` from Hexo `_config.yml` will be used.
   copyright:
+  copyright_url: 
 
   # Powered by Hexo & NexT
   powered: true
@@ -73,6 +74,8 @@ footer:
   beian:
     enable: false
     icp:
+    # ICP region. See: http://www.miit.gov.cn/n1146285/n1146352/n3054355/n3057709/n3057722/c6797266/content.html
+    icp_region: gd
     # The digit in the num of gongan beian.
     gongan_id:
     # The full num of gongan beian.

--- a/layout/_partials/footer.swig
+++ b/layout/_partials/footer.swig
@@ -1,8 +1,14 @@
 {%- if theme.footer.beian.enable %}
   <div class="beian">
-    {{- next_url('http://www.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}
+    <span> ICP:  </span> 
+    {%- if theme.footer.beian.icp_region  and  theme.footer.beian.icp_region != '' %}
+      {%- set icp_region = theme.footer.beian.icp_region %}
+    {%- else %}
+      {%- set icp_region = 'bj' %}
+    {%- endif %}
+    {{- next_url('http://' + icp_region + '.beian.miit.gov.cn', theme.footer.beian.icp + ' ') }}
     {%- if theme.footer.beian.gongan_icon_url %}
-      <img src="{{ url_for(theme.footer.beian.gongan_icon_url) }}" style="display: inline-block;">
+      &nbsp; <img src="{{ url_for(theme.footer.beian.gongan_icon_url) }}" style="display: inline-block;">
     {%- endif %}
     {%- if theme.footer.beian.gongan_id and theme.footer.beian.gongan_num %}
       {{- next_url('http://www.beian.gov.cn/portal/registerSystemInfo?recordcode=' + theme.footer.beian.gongan_id, theme.footer.beian.gongan_num + ' ') }}
@@ -12,12 +18,24 @@
 
 <div class="copyright">
   {% set copyright_year = date(null, 'YYYY') %}
+  <span> Copyright </span>
   &copy; {% if theme.footer.since and theme.footer.since != copyright_year %}{{ theme.footer.since }} – {% endif %}
   <span itemprop="copyrightYear">{{ copyright_year }}</span>
   <span class="with-love">
     <i class="{{ theme.footer.icon.name }}"></i>
   </span>
-  <span class="author" itemprop="copyrightHolder">{{ theme.footer.copyright or author }}</span>
+  {%- if theme.footer.copyright %}
+      {%- set copyright_author = theme.footer.copyright %}
+  {%- else %}
+      {%- set copyright_author = author %}
+  {%- endif %}
+  <span class="author" itemprop="copyrightHolder">
+    {%- if theme.footer.copyright_url %}
+        {{- next_url(theme.footer.copyright_url, copyright_author , {target: '_blank'}) }}
+    {%- else %}
+        {{ copyright_author }}
+    {%- endif %}
+  </span>
 
   {%- if config.symbols_count_time.total_symbols %}
     <span class="post-meta-divider">|</span>

--- a/scripts/tags/mermaid.js
+++ b/scripts/tags/mermaid.js
@@ -7,7 +7,7 @@
 'use strict';
 
 function mermaid(args, content) {
-  return `<pre class="mermaid" style="text-align: center;">
+  return `<pre class="mermaid" style="text-align: center;background: currentColor;">
             ${args.join(' ')}
             ${content}
           </pre>`;


### PR DESCRIPTION
## PR Checklist


- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).

## PR Type

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?

1. `http://www.beian.miit.gov.cn/`  Sometimes the visit is slow
2. mermaid tag. This tag wrong use of .highlight style as background   
![2](https://user-images.githubusercontent.com/31473722/89126871-eb7ea400-d51b-11ea-92f1-2680175d6c1f.jpg)



## What is the new behavior?

1. `http://www.beian.miit.gov.cn/`  Sometimes the visit is slow, it is recommended to use a URL similar to `http://gd.beian.miit.gov.cn/`.  See commit  [e5a1501](https://github.com/theme-next/hexo-theme-next/commit/e5a150156d14da9fd58d6af0e7c85dd2474bc5ae)
    ```
    www.beian.miit.gov.cn => gd.beian.miit.gov.cn
    ```

2. Fix mermaid tag. See commit [91df761](https://github.com/theme-next/hexo-theme-next/commit/91df7613c89b2fb46ad0dd74dd5b4c6d44f2e5b0)
![aa](https://user-images.githubusercontent.com/31473722/89126992-b1fa6880-d51c-11ea-9ff9-b79227b372ab.jpg)



3. Fix foot content display,display the character `Copyright` and add custom links. See commit  [e5a1501](https://github.com/theme-next/hexo-theme-next/commit/e5a150156d14da9fd58d6af0e7c85dd2474bc5ae)
![Copyright](https://user-images.githubusercontent.com/31473722/89118677-121beb00-d4da-11ea-90a9-d7030efb5bc5.jpg)


### How to use?
In NexT `_config.yml`:
```yml
footer:
  ... ...
  # If not defined, `author` from Hexo `_config.yml` will be used.
  copyright:
  copyright_url: 
  ... ...
  # Beian ICP and gongan information for Chinese users. See: http://www.beian.miit.gov.cn, http://www.beian.gov.cn
  beian:
    enable: false
    icp:
    # ICP region. See: http://www.miit.gov.cn/n1146285/n1146352/n3054355/n3057709/n3057722/c6797266/content.html
    icp_region: gd
   ... ...
```
New options is `copyright_url`  and  `icp_region`. 


