### PR TITLE
Make the theme.valine.comment_count parameter work otherwise this Valine’s comment count will be displayed anyway

### DIFF
--- a/scripts/filters/comment/valine.js
+++ b/scripts/filters/comment/valine.js
@@ -22,7 +22,7 @@ hexo.extend.filter.register('theme_inject', injects => {
   if (!theme.valine.enable || !theme.valine.appid || !theme.valine.appkey) return;
 
   injects.postMeta.raw('valine', `
-  {% if post.comments and (is_post() or theme.valine.comment_count) %}
+  {% if post.comments and (is_post() and theme.valine.comment_count) %}
   <span class="post-meta-item">
     ${iconText('far fa-comment', 'valine')}
     <a title="valine" href="{{ url_for(post.path) }}#valine-comments" itemprop="discussionUrl">


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Make the theme.valine.comment_count parameter work, otherwise this Valine’s comment count will be displayed anyway

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A


