### PR TITLE
menu's icon

### DIFF
--- a/layout/_partials/header/menu-item.swig
+++ b/layout/_partials/header/menu-item.swig
@@ -8,7 +8,7 @@
 
     {%- set menuIcon = '' %}
     {%- if theme.menu_settings.icons %}
-      {%- set menuIcon = '<i class="' + value.split('||')[1] | trim + ' fa-fw"></i>' %}
+      {%- set menuIcon = '<i class="fa fa-' + value.split('||')[1] | trim + ' fa-fw"></i>' %}
     {%- endif %}
     {%- set menuText = __('menu.' + name) | replace('menu.', '') %}
 


### PR DESCRIPTION
## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [x] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->
menu's icon went wrong

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: 
![image](https://user-images.githubusercontent.com/53900832/133297361-7c2b4b65-d884-4c5f-a16c-8de7a84f0f9b.png)
![image](https://user-images.githubusercontent.com/53900832/133297781-65149233-886a-4954-9384-5165c53d795d.png)
- Link to demo site with this changes:
https://sevennorth.github.io/AshesBlog/
