### PR TITLE
Add config ignore default language in path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,8 @@ favicon:
 
 # Show multilingual switcher in footer.
 language_switcher: false
+# Ignore default language in path.
+ignore_default_language: true
 
 footer:
   # Specify the date when the site was setup. If not defined, current year will be used.

--- a/layout/_partials/languages.swig
+++ b/layout/_partials/languages.swig
@@ -7,7 +7,7 @@
     </label>
     <select class="lang-select" data-canonical="">
       {% for language in languages %}
-        <option value="{{ language }}" data-href="{{ i18n_path(language) }}" selected="">
+        <option value="{{ language }}" data-href="{{ i18n_path(language, theme.ignore_default_language) }}" selected="">
           {{ language_name(language) }}
         </option>
       {% endfor %}

--- a/scripts/helpers/engine.js
+++ b/scripts/helpers/engine.js
@@ -69,10 +69,10 @@ hexo.extend.helper.register('canonical', function() {
 /**
  * Get page path given a certain language tag
  */
-hexo.extend.helper.register('i18n_path', function(language) {
+hexo.extend.helper.register('i18n_path', function(language, ignore_default_language) {
   const { path, lang } = this.page;
   const base = path.startsWith(lang) ? path.slice(lang.length + 1) : path;
-  return this.url_for(`${this.languages.indexOf(language) === 0 ? '' : '/' + language}/${base}`);
+  return this.url_for(`${this.languages.indexOf(language) === 0 && ignore_default_language ? '' : '/' + language}/${base}`);
 });
 
 /**


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [x] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

According to the Hexo documents([permalinks](https://hexo.io/docs/permalinks) [i18n](https://hexo.io/docs/internationalization)), when config internationalization, the article path formats will include the default language attribute , e.g. 
```yml
# _config.yml
language:
- zh-CN
- en
#...
permalink: :lang/:title/
permalink_defaults:
  lang: zh-CN
#...
new_post_name: :lang/:title.md
```
```yml
# _config.next.yml
language_switcher: true
```
After the real path "zh-CN/Test/" will be replace "Test/" , finally return error code 404.
I think that add a new config to choose ignore or not ignore .

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes:
  - before ![before](https://user-images.githubusercontent.com/55753029/154836446-dc714a16-403d-45a5-a311-7bf21ba6a572.png)
  - after ![after](https://user-images.githubusercontent.com/55753029/154836443-b4be0eea-8ebc-4255-a230-cd2099c0da59.png)
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml
# Ignore default language in path.
ignore_default_language: false
```
