### PR TITLE
Fix Gittalk language wrong for default value, the == '' failed

### DIFF
--- a/layout/_third-party/comments/gitalk.swig
+++ b/layout/_third-party/comments/gitalk.swig
@@ -14,10 +14,10 @@ NexT.utils.loadComments(document.querySelector('#gitalk-container'), () => {
       owner       : '{{ theme.gitalk.github_id }}',
       admin       : ['{{ theme.gitalk.admin_user }}'],
       id          : '{{ gitalk_md5(page.path) }}',
-      {%- if theme.gitalk.language == '' %}
-        language: window.navigator.language || window.navigator.userLanguage,
-      {% else %}
+      {%- if theme.gitalk.language %}
         language: '{{ theme.gitalk.language }}',
+      {%- else %}
+        language: window.navigator.language || window.navigator.userLanguage,
       {%- endif %}
       distractionFreeMode: {{ theme.gitalk.distraction_free_mode }}
     });


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [ ] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

The default `_config.yml` using Gittalk will not use the default `window.navigator.language` for language. Not designed behavior

```
gitalk:
  language:
```

Issue resolved: N/A

## What is the new behavior?
<!-- Description about this pull, in several words -->

- Screenshots with this changes: N/A
- Link to demo site with this changes: N/A

### How to use?
In NexT `_config.yml`:
```yml

```
