### PR TITLE
[Muse & Mist] Footer is not at the bottom of the page when the sidebar display is removed

### DIFF
--- a/source/js/next-boot.js
+++ b/source/js/next-boot.js
@@ -104,6 +104,7 @@ NexT.boot.motion = function() {
       .add(NexT.motion.middleWares.sidebar)
       .bootstrap();
   }
+  if(CONFIG.sidebar.display === 'remove') return;
   NexT.utils.updateSidebarPosition();
 };
 

--- a/source/js/schemes/muse.js
+++ b/source/js/schemes/muse.js
@@ -6,6 +6,14 @@ document.addEventListener('DOMContentLoaded', () => {
   var SIDEBAR_WIDTH = CONFIG.sidebar.width || 320;
   var SIDEBAR_DISPLAY_DURATION = 200;
   var mousePos = {};
+  var isRemove = CONFIG.sidebar.display === 'remove';
+
+  if (isRemove) {
+    updateFooterPosition();
+    window.addEventListener('resize', updateFooterPosition);
+    window.addEventListener('scroll', updateFooterPosition);
+    return;
+  }
 
   var sidebarToggleLines = {
     lines: document.querySelector('.sidebar-toggle'),


### PR DESCRIPTION
<!-- ATTENTION!
1. Please write pull request readme in English, thanks!

2. Always remember that NexT includes 4 schemes. And if on one of them works fine after the changes, on another scheme this changes can be broken. Muse and Mist have similar structure, but Pisces is very difference from them. Gemini is a mirror of Pisces with some styles and layouts remakes. So, please make the tests at least on two schemes (Muse or Mist and Pisces or Gemini).

3. In addition, you need to confirm that the changes made by this PR are compatible with PJAX and Dark Mode.
-->

## PR Checklist <!-- 我确认我已经查看了 -->
<!-- Change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

- [x] The commit message follows [guidelines for NexT](https://github.com/theme-next/hexo-theme-next/blob/master/.github/CONTRIBUTING.md).
- [x] Tests for the changes was maked (for bug fixes / features).
   - [x] Muse | Mist have been tested.
   - [ ] Pisces | Gemini have been tested.(Sidebar display only for Muse|Mist)
- [ ] [Docs](https://github.com/theme-next/theme-next.org/tree/source/source/docs) in [NexT website](https://theme-next.org/docs/) have been added / updated (for features).
<!-- For adding Docs edit needed file here: https://github.com/theme-next/theme-next.org/tree/source/source/docs and create PR with this changes here: https://github.com/theme-next/theme-next.org/pulls -->

## PR Type
<!-- What kind of change does this PR introduce? -->

- [x] Bugfix.
- [ ] Feature.
- [x] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Build & CI related changes.
- [ ] Documentation.
- [ ] Translation. <!-- We use Crowdin to manage translations https://i18n.theme-next.org -->
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue resolved: N/A

Configuration info:
Next version: 7.8.0 (Current latest version)
Scheme: Mist & Muse

When sidebar display is removed,footer is not at the bottom of the page.

<img width="1732" alt="2022-11-15 08 40 41" src="https://user-images.githubusercontent.com/40166184/201810799-961977df-75ab-4a79-bc54-4d575d366d31.png">


## What is the new behavior?
<!-- Description about this pull, in several words -->

when CONFIG.sidebar.display === 'remove', not adjusting the position of the sidebar

<img width="1732" alt="2022-11-15 10 39 27" src="https://user-images.githubusercontent.com/40166184/201813185-d2da2031-ff19-4eb9-971e-f977cccda5b4.png">
